### PR TITLE
feat: enable more powerful vesting accounts

### DIFF
--- a/x/auth/spec/05_vesting.md
+++ b/x/auth/spec/05_vesting.md
@@ -266,8 +266,8 @@ the locked balance, which can be defined as `max(V - DV, 0)`, and infer the
 spendable balance from that.
 
 ```go
-func (va VestingAccount) LockedCoins(t Time) Coins {
-   return max(va.GetVestingCoins(t) - va.DelegatedVesting, 0)
+func (va VestingAccount) LockedCoins(ctx sdk.Context) Coins {
+   return max(va.GetVestingCoins(ctx.BlockTime()) - va.DelegatedVesting, 0)
 }
 ```
 
@@ -279,7 +279,7 @@ func (k Keeper) LockedCoins(ctx Context, addr AccAddress) Coins {
     acc := k.GetAccount(ctx, addr)
     if acc != nil {
         if acc.IsVesting() {
-            return acc.LockedCoins(ctx.BlockTime())
+            return acc.LockedCoins(ctx)
         }
     }
 

--- a/x/auth/vesting/exported/exported.go
+++ b/x/auth/vesting/exported/exported.go
@@ -18,7 +18,7 @@ type VestingAccount interface {
 	// To get spendable coins of a vesting account, first the total balance must
 	// be retrieved and the locked tokens can be subtracted from the total balance.
 	// Note, the spendable balance can be negative.
-	LockedCoins(blockTime time.Time) sdk.Coins
+	LockedCoins(ctx sdk.Context) sdk.Coins
 
 	// TrackDelegation performs internal vesting accounting necessary when
 	// delegating from a vesting account. It accepts the current block time, the

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -263,8 +263,8 @@ func (cva ContinuousVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coi
 
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
-func (cva ContinuousVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return cva.BaseVestingAccount.LockedCoinsFromVesting(cva.GetVestingCoins(blockTime))
+func (cva ContinuousVestingAccount) LockedCoins(ctx sdk.Context) sdk.Coins {
+	return cva.BaseVestingAccount.LockedCoinsFromVesting(cva.GetVestingCoins(ctx.BlockTime()))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -389,8 +389,8 @@ func (pva PeriodicVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins
 
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
-func (pva PeriodicVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return pva.BaseVestingAccount.LockedCoinsFromVesting(pva.GetVestingCoins(blockTime))
+func (pva PeriodicVestingAccount) LockedCoins(ctx sdk.Context) sdk.Coins {
+	return pva.BaseVestingAccount.LockedCoinsFromVesting(pva.GetVestingCoins(ctx.BlockTime()))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -500,8 +500,8 @@ func (dva DelayedVestingAccount) GetVestingCoins(blockTime time.Time) sdk.Coins 
 
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
-func (dva DelayedVestingAccount) LockedCoins(blockTime time.Time) sdk.Coins {
-	return dva.BaseVestingAccount.LockedCoinsFromVesting(dva.GetVestingCoins(blockTime))
+func (dva DelayedVestingAccount) LockedCoins(ctx sdk.Context) sdk.Coins {
+	return dva.BaseVestingAccount.LockedCoinsFromVesting(dva.GetVestingCoins(ctx.BlockTime()))
 }
 
 // TrackDelegation tracks a desired delegation amount by setting the appropriate
@@ -557,7 +557,7 @@ func (plva PermanentLockedAccount) GetVestingCoins(_ time.Time) sdk.Coins {
 
 // LockedCoins returns the set of coins that are not spendable (i.e. locked),
 // defined as the vesting coins that are not delegated.
-func (plva PermanentLockedAccount) LockedCoins(_ time.Time) sdk.Coins {
+func (plva PermanentLockedAccount) LockedCoins(_ sdk.Context) sdk.Coins {
 	return plva.BaseVestingAccount.LockedCoinsFromVesting(plva.OriginalVesting)
 }
 

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -45,6 +45,10 @@ var (
 	initCoins  = sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, initTokens))
 )
 
+func contextAt(t time.Time) sdk.Context {
+	return sdk.Context{}.WithBlockTime(t)
+}
+
 func newFooCoin(amt int64) sdk.Coin {
 	return sdk.NewInt64Coin(fooDenom, amt)
 }
@@ -802,10 +806,10 @@ func (suite *IntegrationTestSuite) TestVestingAccountReceive() {
 	vacc = app.AccountKeeper.GetAccount(ctx, addr1).(*vesting.ContinuousVestingAccount)
 	balances := app.BankKeeper.GetAllBalances(ctx, addr1)
 	suite.Require().Equal(origCoins.Add(sendCoins...), balances)
-	suite.Require().Equal(balances.Sub(vacc.LockedCoins(now)), sendCoins)
+	suite.Require().Equal(balances.Sub(vacc.LockedCoins(contextAt(now))), sendCoins)
 
 	// require coins are spendable plus any that have vested
-	suite.Require().Equal(balances.Sub(vacc.LockedCoins(now.Add(12*time.Hour))), origCoins)
+	suite.Require().Equal(balances.Sub(vacc.LockedCoins(contextAt(now.Add(12*time.Hour)))), origCoins)
 }
 
 func (suite *IntegrationTestSuite) TestPeriodicVestingAccountReceive() {
@@ -841,10 +845,10 @@ func (suite *IntegrationTestSuite) TestPeriodicVestingAccountReceive() {
 	vacc = app.AccountKeeper.GetAccount(ctx, addr1).(*vesting.PeriodicVestingAccount)
 	balances := app.BankKeeper.GetAllBalances(ctx, addr1)
 	suite.Require().Equal(origCoins.Add(sendCoins...), balances)
-	suite.Require().Equal(balances.Sub(vacc.LockedCoins(now)), sendCoins)
+	suite.Require().Equal(balances.Sub(vacc.LockedCoins(contextAt(now))), sendCoins)
 
 	// require coins are spendable plus any that have vested
-	suite.Require().Equal(balances.Sub(vacc.LockedCoins(now.Add(12*time.Hour))), origCoins)
+	suite.Require().Equal(balances.Sub(vacc.LockedCoins(contextAt(now.Add(12*time.Hour)))), origCoins)
 }
 
 func (suite *IntegrationTestSuite) TestDelegateCoins() {

--- a/x/bank/keeper/view.go
+++ b/x/bank/keeper/view.go
@@ -166,7 +166,7 @@ func (k BaseViewKeeper) LockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Co
 	if acc != nil {
 		vacc, ok := acc.(vestexported.VestingAccount)
 		if ok {
-			return vacc.LockedCoins(ctx.BlockTime())
+			return vacc.LockedCoins(ctx)
 		}
 	}
 


### PR DESCRIPTION
Expand the LockedCoins() method to take a full sdk.Context.

## Description

Used in support of https://github.com/Agoric/agoric-sdk/issues/3277 where a new type of "vesting account" will query to the Agoric swingset layer to see if there are any outstanding liens. Needs the full `sdk.Context` to do so.

Not marking as a breaking change, since this interface is not for general consumption.

### Author Checklist

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)