### PR TITLE
chore: merge v0.43.0-rc2 and fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## [v0.43.0-rc2](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.43.0-rc2) - 2021-07-19
+
+### Bug Fixes
+
+* (server) [#9704](https://github.com/cosmos/cosmos-sdk/pull/9704) Start GRPCWebServer in goroutine, avoid blocking other services from starting.
 
 ## [v0.43.0-rc1](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.43.0-rc1) - 2021-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (cli) [\#9593](https://github.com/cosmos/cosmos-sdk/pull/9593) Check if chain-id is blank before verifying signatures in multisign and error.
 
+### Bug Fixes
+
+* (bank) [\#9687](https://github.com/cosmos/cosmos-sdk/issues/9687) fixes [\#9159](https://github.com/cosmos/cosmos-sdk/issues/9159). Added migration to prune balances with zero coins.
+
 ### CLI Breaking Changes
 
 * [\#9621](https://github.com/cosmos/cosmos-sdk/pull/9621) Rollback [\#9371](https://github.com/cosmos/cosmos-sdk/pull/9371) and log warning if there's an empty value for min-gas-price in app.toml

--- a/server/grpc/grpc_web.go
+++ b/server/grpc/grpc_web.go
@@ -1,12 +1,15 @@
 package grpc
 
 import (
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"google.golang.org/grpc"
 
 	"github.com/cosmos/cosmos-sdk/server/config"
+	"github.com/cosmos/cosmos-sdk/server/types"
 )
 
 // StartGRPCWeb starts a gRPC-Web server on the given address.
@@ -28,8 +31,18 @@ func StartGRPCWeb(grpcSrv *grpc.Server, config config.Config) (*http.Server, err
 		Addr:    config.GRPCWeb.Address,
 		Handler: http.HandlerFunc(handler),
 	}
-	if err := grpcWebSrv.ListenAndServe(); err != nil {
+
+	errCh := make(chan error)
+	go func() {
+		if err := grpcWebSrv.ListenAndServe(); err != nil {
+			errCh <- fmt.Errorf("[grpc] failed to serve: %w", err)
+		}
+	}()
+
+	select {
+	case err := <-errCh:
 		return nil, err
+	case <-time.After(types.ServerStartTime): // assume server started successfully
+		return grpcWebSrv, nil
 	}
-	return grpcWebSrv, nil
 }

--- a/server/grpc/server.go
+++ b/server/grpc/server.go
@@ -54,7 +54,7 @@ func StartGRPCServer(clientCtx client.Context, app types.Application, address st
 	select {
 	case err := <-errCh:
 		return nil, err
-	case <-time.After(5 * time.Second): // assume server started successfully
+	case <-time.After(types.ServerStartTime): // assume server started successfully
 		return grpcSrv, nil
 	}
 }

--- a/server/start.go
+++ b/server/start.go
@@ -314,7 +314,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 		select {
 		case err := <-errCh:
 			return err
-		case <-time.After(5 * time.Second): // assume server started successfully
+		case <-time.After(types.ServerStartTime): // assume server started successfully
 		}
 	}
 
@@ -368,7 +368,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 		select {
 		case err := <-errCh:
 			return err
-		case <-time.After(5 * time.Second): // assume server started successfully
+		case <-time.After(types.ServerStartTime): // assume server started successfully
 		}
 	}
 

--- a/server/types/app.go
+++ b/server/types/app.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"io"
+	"time"
 
 	"github.com/gogo/protobuf/grpc"
 	"github.com/spf13/cobra"
@@ -15,6 +16,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/config"
 )
+
+// ServerStartTime defines the time duration that the server need to stay running after startup
+// for the startup be considered successful
+const ServerStartTime = 5 * time.Second
 
 type (
 	// AppOptions defines an interface that is passed into an application

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/server/api"
 	servergrpc "github.com/cosmos/cosmos-sdk/server/grpc"
+	srvtypes "github.com/cosmos/cosmos-sdk/server/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
@@ -90,7 +91,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		select {
 		case err := <-errCh:
 			return err
-		case <-time.After(5 * time.Second): // assume server started successfully
+		case <-time.After(srvtypes.ServerStartTime): // assume server started successfully
 		}
 
 		val.api = apiSrv
@@ -105,21 +106,10 @@ func startInProcess(cfg Config, val *Validator) error {
 		val.grpc = grpcSrv
 
 		if val.AppConfig.GRPCWeb.Enable {
-			errCh1 := make(chan error)
-			go func() {
-				grpcWeb, err := servergrpc.StartGRPCWeb(grpcSrv, *val.AppConfig)
-				if err != nil {
-					errCh1 <- err
-				}
-
-				val.grpcWeb = grpcWeb
-			}()
-			select {
-			case err := <-errCh1:
+			val.grpcWeb, err = servergrpc.StartGRPCWeb(grpcSrv, *val.AppConfig)
+			if err != nil {
 				return err
-			case <-time.After(5 * time.Second): // assume server started successfully
 			}
-
 		}
 	}
 

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -447,7 +447,9 @@ func (m *Manager) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) abci.R
 // child context with an event manager to aggregate events emitted from all
 // modules.
 func (m *Manager) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-	ctx = ctx.WithEventManager(sdk.NewEventManagerWithHistory(ctx.EventManager().GetABCIEventHistory()))
+	if em := ctx.EventManager(); em != nil {
+		ctx = ctx.WithEventManager(sdk.NewEventManagerWithHistory(em.GetABCIEventHistory()))
+	}
 	validatorUpdates := []abci.ValidatorUpdate{}
 
 	for _, moduleName := range m.OrderEndBlockers {

--- a/x/auth/vesting/cmd/vestcalc/vestcalc.go
+++ b/x/auth/vesting/cmd/vestcalc/vestcalc.go
@@ -28,7 +28,7 @@ func divide(total sdk.Int, divisor int) ([]sdk.Int, error) {
 	// Fact: remainder < divisions, hence fits in int64
 	truncated := total.QuoRaw(div64)
 	remainder := total.ModRaw(div64)
-	fraction := sdk.NewInt(0) // poirtion of remainder which has been doled out
+	fraction := sdk.NewInt(0) // portion of remainder which has been doled out
 	for i := int64(0); i < div64; i++ {
 		// multiply will not overflow since remainder and i are < 2^63
 		nextFraction := remainder.MulRaw(i + 1).QuoRaw(div64)
@@ -91,7 +91,7 @@ func monthlyVestTimes(startTime time.Time, months int, timeOfDay time.Time) ([]t
 	second := timeOfDay.Second()
 	times := make([]time.Time, months)
 	for i := 1; i <= months; i++ {
-		tm := startTime.AddDate(0, int(i), 0)
+		tm := startTime.AddDate(0, i, 0)
 		if tm.Day() != startTime.Day() {
 			// The starting day-of-month cannot fit in this month,
 			// and we've wrapped to the next month. Back up to the
@@ -147,6 +147,7 @@ func zipEvents(divisions []sdk.Coins, times []time.Time) ([]event, error) {
 }
 
 // marshalEvents returns a printed representation of events.
+// nolint:unparam
 func marshalEvents(events []event) ([]byte, error) {
 	var b strings.Builder
 	b.WriteString("[\n")
@@ -245,6 +246,7 @@ const day = 24 * time.Hour
 // formatDuration returns a duration in a string like "3d4h3m0.5s".
 // It follows time.Duration.String() except that it includes 24-hour days.
 // NOTE: Does not reflect daylight savings changes.
+// nolint:deadcode,unused
 func formatDuration(d time.Duration) string {
 	s := ""
 	if d < 0 {
@@ -257,22 +259,23 @@ func formatDuration(d time.Duration) string {
 	}
 	// Now we know days are the most significant unit,
 	// so all other units should be present
-	days := int64(d / day)
-	r := d % day // remainder
-	s = s + fmt.Sprint(days) + "d"
+	r := d
+	days := int64(r / day)
+	r %= day // remainder
+	s += fmt.Sprint(days) + "d"
 	hours := int64(r / time.Hour)
-	r = r % time.Hour
-	s = s + fmt.Sprint(hours) + "h"
+	r %= time.Hour
+	s += fmt.Sprint(hours) + "h"
 	minutes := int64(r / time.Minute)
-	r = r % time.Minute
-	s = s + fmt.Sprint(minutes) + "m"
+	r %= time.Minute
+	s += fmt.Sprint(minutes) + "m"
 	seconds := int64(r / time.Second)
-	r = r % time.Second
-	s = s + fmt.Sprint(seconds) // no suffix yet
+	r %= time.Second
+	s += fmt.Sprint(seconds) // no suffix yet
 	if r != 0 {
 		// Follow normal Duration formatting, but need to avoid
 		// the special handling of fractional seconds.
-		r = r + time.Second
+		r += time.Second
 		frac := r.String()
 		// append skipping the leading "1"
 		return s + frac[1:] // adds the suffix
@@ -535,11 +538,12 @@ func writeCmd() {
 // main executes either readCmd() or writeCmd() based on flags.
 func main() {
 	flag.Parse()
-	if *flagRead && !*flagWrite {
+	switch {
+	case *flagRead && !*flagWrite:
 		readCmd()
-	} else if *flagWrite && !*flagRead {
+	case *flagWrite && !*flagRead:
 		writeCmd()
-	} else {
+	default:
 		fmt.Fprintln(os.Stderr, "Must specify one of --read or --write")
 		flag.Usage()
 	}

--- a/x/auth/vesting/cmd/vestcalc/vestcalc_test.go
+++ b/x/auth/vesting/cmd/vestcalc/vestcalc_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	//"encoding/json"
+	// "encoding/json"
 	"reflect"
 	"testing"
 	"time"


### PR DESCRIPTION
Merged upstream v0.43.0-rc2.

Also, fix a problem with `types/module/module.go` where a naive test accidentally crashed because `EndBlock` wasn't defensive against `nil == ctx.EventManager()`.
