### PR TITLE
fix: make proto-check-breaking work for forks

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -26,5 +26,5 @@ jobs:
           PATTERNS: |
             **/**.proto
       - name: check-breakage
-        run: make proto-check-breaking
+        run: make proto-check-breaking PR_TARGET_REPO=https://github.com/${{ github.repository }}.git PR_TARGET_BRANCH=${{ github.base_ref }}
         if: env.GIT_DIFF

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ BINDIR ?= $(GOPATH)/bin
 BUILDDIR ?= $(CURDIR)/build
 SIMAPP = ./simapp
 MOCKS_DIR = $(CURDIR)/tests/mocks
-HTTPS_GIT := https://github.com/cosmos/cosmos-sdk.git
+PR_TARGET_REPO = https://github.com/cosmos/cosmos-sdk.git
+PR_TARGET_BRANCH = master
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 
@@ -415,7 +416,7 @@ proto-lint:
 	@$(DOCKER_BUF) lint --error-format=json
 
 proto-check-breaking:
-	@$(DOCKER_BUF) breaking --against $(HTTPS_GIT)#branch=master
+	@$(DOCKER_BUF) breaking --against $(PR_TARGET_REPO)#branch=$(PR_TARGET_BRANCH)
 
 
 TM_URL              = https://raw.githubusercontent.com/tendermint/tendermint/v0.34.0-rc6/proto/tendermint


### PR DESCRIPTION
## Description

The `make proto-check-breaking` always checks for incompatible proto changes against the `master` branch of `cosmos/cosmos-sdk`, regardless of whether the PR in question is on a fork or release branch.

Changes the workflow to dynamically specify the target repository and branch of the PR, and changes the `Makefile` to accept these parameters. Outside of CI testing, can specify the parameters on the `make` command line.

Probably closes https://github.com/cosmos/cosmos-sdk/issues/8907

---

### Author Checklist

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [X] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)