### PR TITLE
fix: factor out reward when computing reward vesting

### DIFF
--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -976,6 +976,14 @@ func scaleCoins(coins sdk.Coins, scale sdk.Dec) sdk.Coins {
 	return scaledCoins
 }
 
+// minInt returns the minumum of its arguments.
+func minInt(a, b sdk.Int) sdk.Int {
+	if a.GT(b) {
+		return b
+	}
+	return a
+}
+
 // PostReward encumbers a previously-deposited reward according to the current vesting apportionment of staking.
 // Note that rewards might be unvested, but are unlocked.
 func (va ClawbackVestingAccount) PostReward(ctx sdk.Context, reward sdk.Coins, ak AccountKeeper, bk BankKeeper, sk StakingKeeper) {
@@ -998,18 +1006,15 @@ func (va ClawbackVestingAccount) PostReward(ctx sdk.Context, reward sdk.Coins, a
 	// Find current split of account balance on staking axis
 	bonded, unbonding, unbonded := va.findBalance(ctx, bk, sk)
 	total := bonded.Add(unbonding).Add(unbonded)
+	total = total.Sub(minInt(total, reward.AmountOf(bondDenom))) // look at pre-reward total
 
 	// Adjust vested/unvested for the actual amount in the account (transfers, slashing)
-	if unvested.GT(total) {
-		// must have been reduced by slashing
-		unvested = total
-	}
+	// preferring them to be unvested
+	unvested = minInt(unvested, total) // may have been reduced by slashing
 	vested = total.Sub(unvested)
 
 	// Now restrict to just the bonded tokens, preferring them to be vested
-	if vested.GT(bonded) {
-		vested = bonded
-	}
+	vested = minInt(vested, bonded)
 	unvested = bonded.Sub(vested)
 
 	// Compute the unvested amount of reward and add to vesting schedule

--- a/x/auth/vesting/types/vesting_account_test.go
+++ b/x/auth/vesting/types/vesting_account_test.go
@@ -1037,6 +1037,66 @@ func TestClawback(t *testing.T) {
 	require.Equal(t, sdk.NewInt(5), ubd.Entries[0].Balance)
 }
 
+func TestRewards(t *testing.T) {
+	c := sdk.NewCoins
+	stake := func(x int64) sdk.Coin { return sdk.NewInt64Coin(stakeDenom, x) }
+	now := tmtime.Now()
+
+	// set up simapp and validators
+	app := simapp.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{}).WithBlockTime((now))
+	_, val := createValidator(t, ctx, app, 100)
+	require.Equal(t, "stake", app.StakingKeeper.BondDenom(ctx))
+
+	// create vesting account
+	lockupPeriods := types.Periods{
+		{Length: 1, Amount: c(stake(4000))},
+	}
+	vestingPeriods := types.Periods{
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+		{Length: int64(100), Amount: c(stake(500))},
+	}
+	bacc, _ := initBaseAccount()
+	origCoins := c(stake(4000))
+	_, _, funder := testdata.KeyTestPubAddr()
+	va := types.NewClawbackVestingAccount(bacc, funder, origCoins, now.Unix(), lockupPeriods, vestingPeriods)
+	addr := va.GetAddress()
+	app.AccountKeeper.SetAccount(ctx, va)
+
+	// fund the vesting account with 300 stake lost to transfer
+	err := simapp.FundAccount(app.BankKeeper, ctx, addr, c(stake(3700)))
+	require.NoError(t, err)
+	require.Equal(t, int64(3700), app.BankKeeper.GetBalance(ctx, addr, stakeDenom).Amount.Int64())
+	ctx = ctx.WithBlockTime(now.Add(350 * time.Second))
+
+	// delegate 1600
+	shares, err := app.StakingKeeper.Delegate(ctx, addr, sdk.NewInt(1600), stakingtypes.Unbonded, val, true)
+	require.NoError(t, err)
+	require.Equal(t, sdk.NewInt(1600), shares.TruncateInt())
+	require.Equal(t, int64(2100), app.BankKeeper.GetBalance(ctx, addr, stakeDenom).Amount.Int64())
+	va = app.AccountKeeper.GetAccount(ctx, addr).(*types.ClawbackVestingAccount)
+
+	// distribute a reward of 120stake
+	err = simapp.FundAccount(app.BankKeeper, ctx, addr, c(stake(120)))
+	require.NoError(t, err)
+	va.PostReward(ctx, c(stake(120)), app.AccountKeeper, app.BankKeeper, app.StakingKeeper)
+	va = app.AccountKeeper.GetAccount(ctx, addr).(*types.ClawbackVestingAccount)
+	require.Equal(t, int64(4030), va.OriginalVesting.AmountOf(stakeDenom).Int64())
+	require.Equal(t, 8, len(va.VestingPeriods))
+	for i := 0; i < 3; i++ {
+		require.Equal(t, int64(500), va.VestingPeriods[i].Amount.AmountOf(stakeDenom).Int64())
+	}
+	for i := 3; i < 8; i++ {
+		require.Equal(t, int64(506), va.VestingPeriods[i].Amount.AmountOf(stakeDenom).Int64())
+	}
+}
+
 func TestGenesisAccountValidate(t *testing.T) {
 	pubkey := secp256k1.GenPrivKey().PubKey()
 	addr := sdk.AccAddress(pubkey.Address())


### PR DESCRIPTION
Fixed a bug that overcounted the vested tokens in the account, thus undercounted the proportion of the reward to make unvested.