### PR TITLE
fix: prevent panic in Coins.IsEqual

### DIFF
--- a/types/coin.go
+++ b/types/coin.go
@@ -596,7 +596,10 @@ func (coins Coins) IsEqual(coinsB Coins) bool {
 	coinsB = coinsB.Sort()
 
 	for i := 0; i < len(coins); i++ {
-		if !coins[i].IsEqual(coinsB[i]) {
+		if coins[i].Denom != coinsB[i].Denom {
+			return false
+		}
+		if !coins[i].Amount.Equal(coinsB[i].Amount) {
 			return false
 		}
 	}

--- a/types/coin_test.go
+++ b/types/coin_test.go
@@ -411,7 +411,7 @@ func (s *coinTestSuite) TestEqualCoins() {
 		{sdk.Coins{}, sdk.Coins{}, true, false},
 		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, true, false},
 		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, true, false},
-		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom2, 0)}, false, true},
+		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom2, 0)}, false, false},
 		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 1)}, false, false},
 		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, false, false},
 		{sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, sdk.Coins{sdk.NewInt64Coin(testDenom1, 0), sdk.NewInt64Coin(testDenom2, 1)}, true, false},


### PR DESCRIPTION
I'm tired of coding around this. Will upstream later.

The problem is that comparing `{A:1, C:3}` with `{B:2, C:3}` results in a panic, not `false` as one would expect.

Conversations with Cosmos core developers assure me that this is not a deliberate feature, and nothing seems to depend on the panicking behavior.
