### PR TITLE
chore: Change clawback vesting account tests to table-driven tests

### DIFF
--- a/x/auth/vesting/types/vesting_account_test.go
+++ b/x/auth/vesting/types/vesting_account_test.go
@@ -1,7 +1,6 @@
 package types_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -1173,9 +1172,6 @@ func TestClawback(t *testing.T) {
 			// check destination account delegated amount
 			del, found = app.StakingKeeper.GetDelegation(ctx, dest, valAddr)
 			if found {
-				fmt.Println(del)
-				fmt.Println(val.GetDelegatorShares())
-
 				stakeAmt := val.TokensFromSharesTruncated(shares).RoundInt()
 				require.Equal(t, tc.destAccDelegatedAmt, stakeAmt)
 			}


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Changes existing tests for clawback vesting account to table-driven tests. 

Commented out the first test case that has been added since it was giving “division by zero error” when calling method `TokensFromSharesTruncated` for the first test case. `GetDelegation` returns 60 shares while `GetDelegatorShares()`  returns 0.00 which results in a division by zero error in the `TokensFromSharesTruncated` method. Details on why the first test case is giving errors is yet to be known.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)