### PR TITLE
chore: minimize differences with Agoric branch wrt 0.45.4 import

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -423,7 +423,7 @@ func (app *BaseApp) Query(req abci.RequestQuery) (res abci.ResponseQuery) {
 
 	path := splitPath(req.Path)
 	if len(path) == 0 {
-		sdkerrors.QueryResultWithDebug(sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "no query path provided"), app.trace)
+		return sdkerrors.QueryResultWithDebug(sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "no query path provided"), app.trace)
 	}
 
 	switch path[0] {

--- a/contrib/images/simd-env/Dockerfile
+++ b/contrib/images/simd-env/Dockerfile
@@ -2,7 +2,6 @@ FROM golang:1.17-alpine AS build
 RUN apk add build-base git linux-headers
 WORKDIR /work
 COPY go.mod go.sum /work/
-# COPY db/go.mod db/go.sum /work/db/
 
 RUN go mod download
 COPY ./ /work

--- a/x/authz/client/rest/grpc_query_test.go
+++ b/x/authz/client/rest/grpc_query_test.go
@@ -5,7 +5,6 @@ package rest_test
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/suite"
@@ -237,7 +236,7 @@ func (s *IntegrationTestSuite) TestQueryGrantsGRPC() {
 
 func (s *IntegrationTestSuite) TestQueryGranterGrantsGRPC() {
 	val := s.network.Validators[0]
-	grantee := s.grantee[1]
+	grantee := s.grantee
 	require := s.Require()
 
 	testCases := []struct {
@@ -290,7 +289,7 @@ func (s *IntegrationTestSuite) TestQueryGranterGrantsGRPC() {
 
 func (s *IntegrationTestSuite) TestQueryGranteeGrantsGRPC() {
 	val := s.network.Validators[0]
-	grantee := s.grantee[1]
+	grantee := s.grantee
 	require := s.Require()
 
 	testCases := []struct {


### PR DESCRIPTION
Refs: Agoric/agoric-sdk#5773

Resolve differences in the import of cosmos/cosmos-sdk v0.45.4 between the `Agoric` and `Agoric-ag0-45` branches.
