### PR TITLE
refactor: Remove CommitWithoutSnapshot method

### DIFF
--- a/snapshots/manager.go
+++ b/snapshots/manager.go
@@ -522,7 +522,7 @@ func (m *Manager) SnapshotIfApplicable(height int64) {
 
 // shouldTakeSnapshot returns true is snapshot should be taken at height.
 func (m *Manager) shouldTakeSnapshot(height int64) bool {
-	return m.opts.Interval > 0 && uint64(height)%m.opts.Interval == 0
+	return height > 0 && m.opts.Interval > 0 && uint64(height)%m.opts.Interval == 0
 }
 
 // Snapshot taks a snapshot of the current state and prunes any old snapshottypes.


### PR DESCRIPTION
Functionality seems to be covered by the upstream `SnapshotIfApplicable`, although I did add a `height > 0` guard. But I'm no longer convinced that this is the actual issue... @JimLarson, how did you encounter the snapshot issue in the first place?

## Details

[Current main-branch state](https://github.com/agoric-labs/cosmos-sdk/blob/23834d90d2e1b9423185bfc36d60120a124dc85b/baseapp/abci.go#L306-L439) includes `CommitWithoutSnapshot`, and is basically
```go
func (app *BaseApp) Commit() abci.ResponseCommit {
	res, snapshotHeight := app.CommitWithoutSnapshot()

	if snapshotHeight > 0 {
		go app.Snapshot(snapshotHeight)
	}

	return res
}

// CommitWithoutSnapshot is like Commit but instead of starting the snapshot goroutine
// it returns a positive snapshot height.
// It can be used by apps to synchronize snapshots according to their requirements.
func (app *BaseApp) CommitWithoutSnapshot() (abci.ResponseCommit, int64) {
	…

	var snapshotHeight int64
	if app.snapshotInterval > 0 && uint64(header.Height)%app.snapshotInterval == 0 {
		snapshotHeight = header.Height
	}

	return res, snapshotHeight
}

// Snapshot takes a snapshot of the current state and prunes any old snapshottypes.
// It should be started as a goroutine
func (app *BaseApp) Snapshot(height int64) {
	if app.snapshotManager == nil {
		app.logger.Info("snapshot manager not configured")
		return
	}

	…
}
```

State as of this PR has a much smaller diff from [upstream v0.46.16](https://github.com/agoric-labs/cosmos-sdk/blob/7799bba7bc889288607576aa11655b5fc31a2da9/baseapp/abci.go#L298-L359)—identical `func (app *BaseApp) Commit()` with some tweaks in snapshots/manager.go, excerpted here (where the only change from this PR is addition of `height > 0`):
```diff
--- snapshots/manager.go
+++ snapshots/manager.go
@@ -482,29 +510,31 @@ func IsFormatSupported(snapshotter types.ExtensionSnapshotter, format uint32) bo
 // SnapshotIfApplicable takes a snapshot of the current state if we are on a snapshot height.
 // It also prunes any old snapshots.
 func (m *Manager) SnapshotIfApplicable(height int64) {
        if m == nil {
                return
        }
        if !m.shouldTakeSnapshot(height) {
                m.logger.Debug("snapshot is skipped", "height", height)
                return
        }
-       m.snapshot(height)
+       m.Snapshot(height)
 }
 
 // shouldTakeSnapshot returns true is snapshot should be taken at height.
 func (m *Manager) shouldTakeSnapshot(height int64) bool {
-       return m.opts.Interval > 0 && uint64(height)%m.opts.Interval == 0
+       return height > 0 && m.opts.Interval > 0 && uint64(height)%m.opts.Interval == 0
 }
 
-func (m *Manager) snapshot(height int64) {
+// Snapshot taks a snapshot of the current state and prunes any old snapshottypes.
+// It should be started as a goroutine
+func (m *Manager) Snapshot(height int64) {
        m.logger.Info("creating state snapshot", "height", height)
 
        if height <= 0 {
                m.logger.Error("snapshot height must be positive", "height", height)
                return
        }
 
        snapshot, err := m.Create(uint64(height))
        if err != nil {
                m.logger.Error("failed to create state snapshot", "height", height, "err", err)
```