### PR TITLE
fix: Correct CommitWithoutSnapshot response to indicate the need for a snapshot

### DIFF
--- a/snapshots/manager.go
+++ b/snapshots/manager.go
@@ -513,15 +513,15 @@ func (m *Manager) SnapshotIfApplicable(height int64) {
 	if m == nil {
 		return
 	}
-	if !m.shouldTakeSnapshot(height) {
+	if !m.ShouldTakeSnapshot(height) {
 		m.logger.Debug("snapshot is skipped", "height", height)
 		return
 	}
 	m.Snapshot(height)
 }
 
-// shouldTakeSnapshot returns true is snapshot should be taken at height.
-func (m *Manager) shouldTakeSnapshot(height int64) bool {
+// ShouldTakeSnapshot returns true if a snapshot should be taken at height.
+func (m *Manager) ShouldTakeSnapshot(height int64) bool {
 	return m.opts.Interval > 0 && uint64(height)%m.opts.Interval == 0
 }
 


### PR DESCRIPTION
## Details

[Current main-branch state](https://github.com/agoric-labs/cosmos-sdk/blob/23834d90d2e1b9423185bfc36d60120a124dc85b/baseapp/abci.go#L306-L439) includes `CommitWithoutSnapshot`, and is basically
```go
func (app *BaseApp) Commit() abci.ResponseCommit {
	res, snapshotHeight := app.CommitWithoutSnapshot()

	if snapshotHeight > 0 {
		go app.Snapshot(snapshotHeight)
	}

	return res
}

// CommitWithoutSnapshot is like Commit but instead of starting the snapshot goroutine
// it returns a positive snapshot height.
// It can be used by apps to synchronize snapshots according to their requirements.
func (app *BaseApp) CommitWithoutSnapshot() (abci.ResponseCommit, int64) {
	…

	var snapshotHeight int64
	if app.snapshotInterval > 0 && uint64(header.Height)%app.snapshotInterval == 0 {
		snapshotHeight = header.Height
	}

	return res, snapshotHeight
}

// Snapshot takes a snapshot of the current state and prunes any old snapshottypes.
// It should be started as a goroutine
func (app *BaseApp) Snapshot(height int64) {
	if app.snapshotManager == nil {
		app.logger.Info("snapshot manager not configured")
		return
	}

	…
}
```

State as of this PR has a much smaller [diff](https://github.com/agoric-labs/cosmos-sdk/compare/7799bba7bc889288607576aa11655b5fc31a2da9..gibson042:cosmos-sdk:gibson-release-14-fix-commitwithoutsnapshot?expand=1#diff-389d02f089ab55575400f5300d3c5cfe277fde5f04bd0fe6a85456a7252d1099R311) from [upstream v0.46.16](https://github.com/agoric-labs/cosmos-sdk/blob/7799bba7bc889288607576aa11655b5fc31a2da9/baseapp/abci.go#L298-L359)—`func (app *BaseApp) Commit()` is basically split into `app.CommitWithoutSnapshot()` (encapsulating everything in the upstream code before `go app.snapshotManager.SnapshotIfApplicable(header.Height)` and replacing that with a call to `app.snapshotManager.ShouldTakeSnapshot(header.Height)`, which is accomplished by making `shouldTakeSnapshot` public) and then the rest of `Commit` (which is overridden in agoric-sdk) acts on that data to invoke `app.snapshotManager.Snapshot(snapshotHeight)`.