### PR TITLE
feat!: have tx gov submit-proposal accept either new or legacy syntax

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog (Agoric fork)
 
+## `v0.46.16-alpha.agoric.2` - 2024-02-08
+
+* Agoric/agoric-sdk#8871 Have `tx gov submit-proposal` accept either new or legacy syntax
+
 ## `v0.46.16-alpha.agoric.1` - 2024-02-05
 
 * Agoric/agoric-sdk#8224 Merge [cosmos/cosmos-sdk v0.46.16](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.16)

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -59,32 +59,34 @@ func NewTxCmd(legacyPropCmds []*cobra.Command) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmdSubmitLegacyProp := NewCmdSubmitLegacyProposal()
+	cmdSubmitProp := NewCmdSubmitProposal()
 	for _, propCmd := range legacyPropCmds {
 		flags.AddTxFlagsToCmd(propCmd)
-		cmdSubmitLegacyProp.AddCommand(propCmd)
+		cmdSubmitProp.AddCommand(propCmd)
 	}
 
 	govTxCmd.AddCommand(
 		NewCmdDeposit(),
 		NewCmdVote(),
 		NewCmdWeightedVote(),
-		NewCmdSubmitProposal(),
+		cmdSubmitProp,
 		NewCmdDraftProposal(),
-
-		// Deprecated
-		cmdSubmitLegacyProp,
 	)
 
 	return govTxCmd
 }
 
 // NewCmdSubmitProposal implements submitting a proposal transaction command.
+// NOTE: This command has been modified from its original to subsume both
+// the "legacy" and the new (as of v0.46) invocation patterns. This modification
+// will be dropped once all legacy call sites have been updated to either
+// use the new pattern or call the legacy command explicitly.
 func NewCmdSubmitProposal() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "submit-proposal [path/to/proposal.json]",
-		Short: "Submit a proposal along with some messages, metadata and deposit",
-		Args:  cobra.ExactArgs(1),
+		Use:     "submit-proposal [path/to/proposal.json]",
+		Short:   "Submit a proposal along with some messages, metadata and deposit",
+		Aliases: []string{"submit-legacy-proposal"},
+		Args:    cobra.MaximumNArgs(1),
 		Long: strings.TrimSpace(
 			fmt.Sprintf(`Submit a proposal along with some messages, metadata and deposit.
 They should be defined in a JSON file.
@@ -107,43 +109,9 @@ Where proposal.json contains:
   "metadata: "4pIMOgIGx1vZGU=", // base64-encoded metadata
   "deposit": "10stake"
 }
-`,
-				version.AppName,
-			),
-		),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
 
-			msgs, metadata, deposit, err := parseSubmitProposal(clientCtx.Codec, args[0])
-			if err != nil {
-				return err
-			}
-
-			msg, err := v1.NewMsgSubmitProposal(msgs, deposit, clientCtx.GetFromAddress().String(), metadata)
-			if err != nil {
-				return fmt.Errorf("invalid message: %w", err)
-			}
-
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
-		},
-	}
-
-	flags.AddTxFlagsToCmd(cmd)
-
-	return cmd
-}
-
-// NewCmdSubmitLegacyProposal implements submitting a proposal transaction command.
-// Deprecated: please use NewCmdSubmitProposal instead.
-func NewCmdSubmitLegacyProposal() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "submit-legacy-proposal",
-		Short: "Submit a legacy proposal along with an initial deposit",
-		Long: strings.TrimSpace(
-			fmt.Sprintf(`Submit a legacy proposal along with an initial deposit.
+Legacy Syntax:
+Submit a legacy proposal along with an initial deposit.
 Proposal title, description, type and deposit can be given directly or through a proposal JSON file.
 
 Example:
@@ -162,7 +130,7 @@ Which is equivalent to:
 
 $ %s tx gov submit-legacy-proposal --title="Test Proposal" --description="My awesome proposal" --type="Text" --deposit="10test" --from mykey
 `,
-				version.AppName, version.AppName,
+				version.AppName, version.AppName, version.AppName,
 			),
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -171,22 +139,39 @@ $ %s tx gov submit-legacy-proposal --title="Test Proposal" --description="My awe
 				return err
 			}
 
+			// try to interpret as a legacy submit-proposal call
 			proposal, err := parseSubmitLegacyProposalFlags(cmd.Flags())
-			if err != nil {
-				return fmt.Errorf("failed to parse proposal: %w", err)
+			if err == nil {
+				amount, err := sdk.ParseCoinsNormalized(proposal.Deposit)
+				if err != nil {
+					return err
+				}
+
+				content, ok := v1beta1.ContentFromProposalType(proposal.Title, proposal.Description, proposal.Type)
+				if !ok {
+					return fmt.Errorf("failed to create proposal content: unknown proposal type %s", proposal.Type)
+				}
+
+				msg, err := v1beta1.NewMsgSubmitProposal(content, amount, clientCtx.GetFromAddress())
+				if err != nil {
+					return fmt.Errorf("invalid message: %w", err)
+				}
+
+				return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 			}
 
-			amount, err := sdk.ParseCoinsNormalized(proposal.Deposit)
+			// otherwise try to interpret as a new (0.46) submit-proposal
+			err = cobra.ExactArgs(1)(cmd, args)
 			if err != nil {
 				return err
 			}
 
-			content, ok := v1beta1.ContentFromProposalType(proposal.Title, proposal.Description, proposal.Type)
-			if !ok {
-				return fmt.Errorf("failed to create proposal content: unknown proposal type %s", proposal.Type)
+			msgs, metadata, deposit, err := parseSubmitProposal(clientCtx.Codec, args[0])
+			if err != nil {
+				return err
 			}
 
-			msg, err := v1beta1.NewMsgSubmitProposal(content, amount, clientCtx.GetFromAddress())
+			msg, err := v1.NewMsgSubmitProposal(msgs, deposit, clientCtx.GetFromAddress().String(), metadata)
 			if err != nil {
 				return fmt.Errorf("invalid message: %w", err)
 			}
@@ -203,6 +188,13 @@ $ %s tx gov submit-legacy-proposal --title="Test Proposal" --description="My awe
 	flags.AddTxFlagsToCmd(cmd)
 
 	return cmd
+}
+
+// NewCmdSubmitLegacyProposal implements submitting a proposal transaction command.
+// Deprecated: please use NewCmdSubmitProposal instead.
+// Preserved for tests.
+func NewCmdSubmitLegacyProposal() *cobra.Command {
+	return NewCmdSubmitProposal()
 }
 
 // NewCmdDeposit implements depositing tokens for an active proposal.


### PR DESCRIPTION
Have submit-legacy-proposal be an alias for submit-proposal. Invocations of the legacy syntax should either upgrade to the new syntax, or explicitly use submit-legacy-proposal. When all legacy usages have so migrated, this change can be dropped. See Agoric/agoric-sdk#8871.

## Description

Refs: #8871

Alter the `tx gov submit-proposal` command so that it works either with the new or legacy syntax, and also alias it as `submit-legacy-proposal`. Users of the legacy command will continue to work as-is, but over time they should either explicitly use `submit-legacy-proposal`, or upgrade to the new syntax. When all call sites have done one or the other of these choices, we can drop our modification to this command.

The slight limitation of this approach is that you cannot name the new-syntax JSON file the same as one of the legacy subcommands.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
