### PR TITLE
chore: silence some lint warnings

### DIFF
--- a/x/auth/vesting/cmd/vestcalc/vestcalc.go
+++ b/x/auth/vesting/cmd/vestcalc/vestcalc.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/client/cli"
 )
@@ -18,7 +19,7 @@ import (
 
 // divide returns the division of total as evenly as possible.
 // Divisor must be 1 or greater and total must be nonnegative.
-func divide(total sdk.Int, divisor int) ([]sdk.Int, error) {
+func divide(total sdkmath.Int, divisor int) ([]sdkmath.Int, error) {
 	if divisor < 1 {
 		return nil, fmt.Errorf("divisions must be 1 or greater")
 	}
@@ -26,7 +27,7 @@ func divide(total sdk.Int, divisor int) ([]sdk.Int, error) {
 	if total.IsNegative() {
 		return nil, fmt.Errorf("total must be nonnegative")
 	}
-	divisions := make([]sdk.Int, divisor)
+	divisions := make([]sdkmath.Int, divisor)
 
 	// Ideally we could compute total of the first i divisions as
 	//     cumulative(i) = floor((total * i) / divisor)
@@ -68,7 +69,7 @@ func divideCoins(coins sdk.Coins, divisor int) ([]sdk.Coins, error) {
 		return nil, fmt.Errorf("divisor must be 1 or greater")
 	}
 	divisions := make([]sdk.Coins, divisor)
-	divisionsByDenom := make(map[string][]sdk.Int)
+	divisionsByDenom := make(map[string][]sdkmath.Int)
 	for _, coin := range coins {
 		dividedCoin, err := divide(coin.Amount, divisor)
 		if err != nil {

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -1087,6 +1087,9 @@ func (va *BaseVestingAccount) forceTransfer(ctx sdk.Context, amt sdk.Coins, dest
 	gotCoins = gotCoins.Sub(decrVesting...)
 	ak.SetAccount(ctx, va)
 	// gotCoins should be zero at this point, unless DF+DV was not accurate
+	if !gotCoins.IsZero() {
+		ctx.Logger().Error("more staked than tracked in vesting delegation - %s undercounted by %s", va.Address, gotCoins)
+	}
 
 	// If we've transferred everything and still haven't transferred the desired clawback amount,
 	// then the account must have lost some unvested tokens from slashing.

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -976,7 +976,7 @@ func (k Keeper) Undelegate(
 // TransferUnbonding changes the ownership of UnbondingDelegation entries
 // until the desired number of tokens have changed hands. Returns the actual
 // number of tokens transferred.
-func (k Keeper) TransferUnbonding(ctx sdk.Context, fromAddr, toAddr sdk.AccAddress, valAddr sdk.ValAddress, wantAmt sdk.Int) sdk.Int {
+func (k Keeper) TransferUnbonding(ctx sdk.Context, fromAddr, toAddr sdk.AccAddress, valAddr sdk.ValAddress, wantAmt math.Int) math.Int {
 	transferred := sdk.ZeroInt()
 	ubdFrom, found := k.GetUnbondingDelegation(ctx, fromAddr, valAddr)
 	if !found {


### PR DESCRIPTION
## Description

Refs: Agoric/agoric-sdk#9034

Clean up some lint warnings in our added or modified code.

Not trying to fix errors that are not fixed in the surrounding code, e.g. `Wrapf()`.
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
