### PR TITLE
fix!: update the fee collector name to match Agoric usage

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -41,6 +41,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (auth, bank) Agoric/agoric-sdk#8989 Remove deprecated lien support
 
+### State Machine Breaking
+
+* (auth) [#406](https://github.com/agoric-labs/cosmos-sdk/pull/406) Change name of fee collector module account to match Agoric usage.
+
 ## `v0.46.16-alpha.agoric.2` - 2024-02-08
 
 * Agoric/agoric-sdk#8871 Have `tx gov submit-proposal` accept either new or legacy syntax

--- a/x/auth/types/keys.go
+++ b/x/auth/types/keys.go
@@ -12,7 +12,7 @@ const (
 	StoreKey = "acc"
 
 	// FeeCollectorName the root string for the fee collector account address
-	FeeCollectorName = "fee_collector"
+	FeeCollectorName = "vbank/reserve"
 
 	// QuerierRoute is the querier route for auth
 	QuerierRoute = ModuleName

--- a/x/auth/types/keys.go
+++ b/x/auth/types/keys.go
@@ -12,6 +12,7 @@ const (
 	StoreKey = "acc"
 
 	// FeeCollectorName the root string for the fee collector account address
+	// Agoric: maintain compatibility with Agoric/agoric-sdk/golang/cosmos/x/vbank/types.ReservePoolName
 	FeeCollectorName = "vbank/reserve"
 
 	// QuerierRoute is the querier route for auth


### PR DESCRIPTION
## Description

Refs: Agoric/agoric-sdk#9036

Update the fee collector module account name to match Agoric usage.

This eliminates the need for Agoric/agoric-sdk to maintain its own clone of `DeductFeeDecorator`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
