### PR TITLE
feat: feature flag for ABCI client type

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * (auth) [#407](https://github.com/agoric-labs/cosmos-sdk/pull/407) Configurable fee collector module account in DeductFeeDecorator.
+* (server) [#409](https://github.com/agoric-labs/cosmos-sdk/pull/409) Flag to select ABCI client type.
 
 ### API Breaking
 

--- a/server/start.go
+++ b/server/start.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tendermint/tendermint/abci/server"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tcmd "github.com/tendermint/tendermint/cmd/cometbft/commands"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/node"
@@ -59,6 +60,7 @@ const (
 	FlagIAVLCacheSize       = "iavl-cache-size"
 	FlagDisableIAVLFastNode = "iavl-disable-fastnode"
 	FlagIAVLLazyLoading     = "iavl-lazy-loading"
+	FlagAbciClientType      = "abci-client-type"
 
 	// state sync-related flags
 	FlagStateSyncSnapshotInterval   = "state-sync.snapshot-interval"
@@ -80,6 +82,11 @@ const (
 	flagGRPCAddress    = "grpc.address"
 	flagGRPCWebEnable  = "grpc-web.enable"
 	flagGRPCWebAddress = "grpc-web.address"
+)
+
+const (
+	abciClientTypeCommitting = "committing"
+	abciClientTypeLocal      = "local"
 )
 
 // StartCmd runs the service passed in, either stand-alone or in-process with
@@ -142,9 +149,18 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 				})
 			}
 
+			abciClientType, err := cmd.Flags().GetString(FlagAbciClientType)
+			if err != nil {
+				return err
+			}
+			clientCreator, err := getAbciClientCreator(abciClientType)
+			if err != nil {
+				return err
+			}
+
 			// amino is needed here for backwards compatibility of REST routes
 			err = wrapCPUProfile(serverCtx, func() error {
-				return startInProcess(serverCtx, clientCtx, appCreator)
+				return startInProcess(serverCtx, clientCtx, appCreator, clientCreator)
 			})
 			errCode, ok := err.(ErrorCode)
 			if !ok {
@@ -194,6 +210,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
 	cmd.Flags().Bool(FlagDisableIAVLFastNode, false, "Disable fast node for IAVL tree")
+	cmd.Flags().String(FlagAbciClientType, abciClientTypeCommitting, fmt.Sprintf(`Type of ABCI client ("%s" or "%s")`, abciClientTypeCommitting, abciClientTypeLocal))
 
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)
@@ -254,7 +271,9 @@ func startStandAlone(ctx *Context, appCreator types.AppCreator) error {
 	return WaitForQuitSignals()
 }
 
-func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.AppCreator) error {
+type abciClientCreator func(abcitypes.Application) proxy.ClientCreator
+
+func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.AppCreator, clientCreator abciClientCreator) error {
 	cfg := ctx.Config
 	home := cfg.RootDir
 
@@ -302,7 +321,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 			cfg,
 			pvm.LoadOrGenFilePV(cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile()),
 			nodeKey,
-			proxy.NewCommittingClientCreator(app),
+			clientCreator(app),
 			genDocProvider,
 			node.DefaultDBProvider,
 			node.DefaultMetricsProvider(cfg.Instrumentation),
@@ -499,6 +518,16 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 
 	// wait for signal capture and gracefully return
 	return WaitForQuitSignals()
+}
+
+func getAbciClientCreator(abciClientType string) (abciClientCreator, error) {
+	switch abciClientType {
+	case abciClientTypeCommitting:
+		return proxy.NewCommittingClientCreator, nil
+	case abciClientTypeLocal:
+		return proxy.NewLocalClientCreator, nil
+	}
+	return nil, fmt.Errorf(`unknown ABCI client type "%s"`, abciClientType)
 }
 
 func startTelemetry(cfg serverconfig.Config) (*telemetry.Metrics, error) {

--- a/server/start_test.go
+++ b/server/start_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func TestAbciClientType(t *testing.T) {
+	for _, tt := range []struct {
+		clientType  string
+		creatorName string
+		wantErr     bool
+	}{
+		{
+			clientType:  "committing",
+			creatorName: "github.com/tendermint/tendermint/proxy.NewCommittingClientCreator",
+		},
+		{
+			clientType:  "local",
+			creatorName: "github.com/tendermint/tendermint/proxy.NewLocalClientCreator",
+		},
+		{
+			clientType: "cool ranch",
+			wantErr:    true,
+		},
+	} {
+		t.Run(tt.clientType, func(t *testing.T) {
+			creator, err := getAbciClientCreator(tt.clientType)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("wanted error, got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error %v", err)
+				} else {
+					creatorName := runtime.FuncForPC(reflect.ValueOf(creator).Pointer()).Name()
+					if creatorName != tt.creatorName {
+						t.Errorf(`want creator "%s", got "%s"`, tt.creatorName, creatorName)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Refs: Agoric/agoric-sdk#9224

Adds a feature flag for selecting the type of ABCI client for a server.

The unit test is shameful, but having no test is more shameful.

---

## Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` in the type prefix if API or client breaking change
* [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] provided a link to the relevant issue or specification
* [x] reviewed "Files changed" and left comments if necessary
* [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [x] added a changelog entry to `CHANGELOG.md`
* [x] updated the relevant documentation or specification, including comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] confirmed all CI checks have passed

## Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic, API design and naming, documentation is accurate, tests and test coverage
