### PR TITLE
feat: abci client type now an explicit config setting

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (auth) [#407](https://github.com/agoric-labs/cosmos-sdk/pull/407) Configurable fee collector module account in DeductFeeDecorator.
 * (server) [#409](https://github.com/agoric-labs/cosmos-sdk/pull/409) Flag to select ABCI client type.
+* (server) [#416](https://github.com/agoric-labs/cosmos-sdk/pull/416) Config entry to select ABCI client type.
 * (deps) [#412](https://github.com/agoric-labs/cosmos-sdk/pull/412) Bump iavl to v0.19.7
 * (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Unit tests and documentation for event history.
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -14,8 +14,17 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// [AGORIC] Valid values for FlagAbciClientType
+const (
+	AbciClientTypeCommitting = "committing"
+	AbciClientTypeLocal      = "local"
+)
+
 const (
 	defaultMinGasPrices = ""
+
+	// DefaultABCIClientType defines the default ABCI client type to use with cometbft.
+	DefaultABCIClientType = AbciClientTypeCommitting // [AGORIC]
 
 	// DefaultAPIAddress defines the default address to bind the API server to.
 	DefaultAPIAddress = "tcp://0.0.0.0:1317"

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -301,7 +301,7 @@ func DefaultConfig() *Config {
 			IAVLCacheSize:       781250, // 50 MB
 			IAVLDisableFastNode: false,
 			IAVLLazyLoading:     false,
-			ABCIClientType:      "committing", // [AGORIC]
+			ABCIClientType:      DefaultABCIClientType, // [AGORIC]
 			AppDBBackend:        "",
 		},
 		Telemetry: telemetry.Config{

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -94,6 +94,9 @@ type BaseConfig struct {
 	// IAVLLazyLoading enable/disable the lazy loading of iavl store.
 	IAVLLazyLoading bool `mapstructure:"iavl-lazy-loading"`
 
+	// ABCIClientType selects the type of ABCI client.
+	ABCIClientType string `mapstructure:"abci-client-type"`
+
 	// AppDBBackend defines the type of Database to use for the application and snapshots databases.
 	// An empty string indicates that the Tendermint config's DBBackend value should be used.
 	AppDBBackend string `mapstructure:"app-db-backend"`
@@ -289,6 +292,7 @@ func DefaultConfig() *Config {
 			IAVLCacheSize:       781250, // 50 MB
 			IAVLDisableFastNode: false,
 			IAVLLazyLoading:     false,
+			ABCIClientType:      "committing", // [AGORIC]
 			AppDBBackend:        "",
 		},
 		Telemetry: telemetry.Config{

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -82,6 +82,10 @@ iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 # Default is false.
 iavl-lazy-loading = {{ .BaseConfig.IAVLLazyLoading }}
 
+# ABCIClientType selects the type of ABCI client.
+# Default is "committing".
+abci-client-type = "{{ .BaseConfig.ABCIClientType }}"
+
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
 # An empty string indicates that a fallback will be used.
 # First fallback is the deprecated compile-time types.DBBackend value.

--- a/server/start.go
+++ b/server/start.go
@@ -84,12 +84,6 @@ const (
 	flagGRPCWebAddress = "grpc-web.address"
 )
 
-// [AGORIC] Valid values for FlagAbciClientType
-const (
-	abciClientTypeCommitting = "committing"
-	abciClientTypeLocal      = "local"
-)
-
 // StartCmd runs the service passed in, either stand-alone or in-process with
 // Tendermint.
 func StartCmd(appCreator types.AppCreator, defaultNodeHome string) *cobra.Command {
@@ -202,7 +196,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
 	cmd.Flags().Bool(FlagDisableIAVLFastNode, false, "Disable fast node for IAVL tree")
-	cmd.Flags().String(FlagAbciClientType, abciClientTypeCommitting, fmt.Sprintf(`Type of ABCI client ("%s" or "%s")`, abciClientTypeCommitting, abciClientTypeLocal))
+	cmd.Flags().String(FlagAbciClientType, serverconfig.DefaultABCIClientType, fmt.Sprintf(`Type of ABCI client ("%s" or "%s")`, serverconfig.AbciClientTypeCommitting, serverconfig.AbciClientTypeLocal))
 
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)
@@ -524,9 +518,9 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 // [AGORIC] Allows us to disable committingClient.
 func getAbciClientCreator(abciClientType string) (abciClientCreator, error) {
 	switch abciClientType {
-	case abciClientTypeCommitting:
+	case serverconfig.AbciClientTypeCommitting:
 		return proxy.NewCommittingClientCreator, nil
-	case abciClientTypeLocal:
+	case serverconfig.AbciClientTypeLocal:
 		return proxy.NewLocalClientCreator, nil
 	}
 	return nil, fmt.Errorf(`unknown ABCI client type "%s"`, abciClientType)


### PR DESCRIPTION
## Description

Refs: https://github.com/Agoric/agoric-sdk/issues/9224

Add an explicit entry for abci-client-type in the TOML file. The setting can be done in the file but is overridden by when the command-line flag is set.

Note that this entry is unlike the other entries in the "base config" part of the TOML file, in that there are no `BaseApp.Get/SetABCIClientType()` methods, option helpers, etc. This makes it more like the various start command flags that do not have explicit config fields, e.g. `--with-tendermint` or `--trace-store`. This seems appropriate for a setting that is used near the "top" of the start command.

Note that even without this change, the option can be set in the `config/app.toml` file. This just makes the entry part of the automatically-generated TOML file.

Note that the default value is now specified both in the flag definition and in the default config constructor, as some of the other flags are. It's confusing to think about which one takes precedence, so they should just be kept in sync.

Tested the following:

- start with default toml file which includes and explicit entry to the default "committing" value
- start with an illegal value - fails as expected
- start with non-default valid value "local"
- start with line removed from `app.toml`
- override with flag set to an illegal value - fails as expected
- override with flag set to "committing"
- restore `app.toml` entry and override with a different legal value
- override with illegal flag - still fails as expected.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
