### PR TITLE
chore: cherry-pick and update docs for v0.46.16-alpha.agoric.2.3

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -45,19 +45,27 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (auth, bank) Agoric/agoric-sdk#8989 Remove deprecated lien support
 
+## `v0.46.16-alpha.agoric.2.3` - 2024-04-17
+
+### Improvements
+
+* (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Unit tests and documentation for event history.
+* (server) [#416](https://github.com/agoric-labs/cosmos-sdk/pull/416) Config entry to select ABCI client type.
+
+### Bug Fixes
+
+* (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Avoid duplicates in event history.
+
 ## `v0.46.16-alpha.agoric.2.2` - 2024-04-12
 
 ### Improvements
 
 * (server) [#409](https://github.com/agoric-labs/cosmos-sdk/pull/409) Flag to select ABCI client type.
-* (server) [#416](https://github.com/agoric-labs/cosmos-sdk/pull/416) Config entry to select ABCI client type.
 * (deps) [#412](https://github.com/agoric-labs/cosmos-sdk/pull/412) Bump iavl to v0.19.7
-* (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Unit tests and documentation for event history.
 
 ### Bug Fixes
 
 * (baseapp) [#413](https://github.com/agoric-labs/cosmos-sdk/pull/413) Ignore events from simulated transactions
-* (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Avoid duplicates in event history.
 
 ## `v0.46.16-alpha.agoric.2.1` - 2024-03-08
 

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -50,6 +50,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * (server) [#409](https://github.com/agoric-labs/cosmos-sdk/pull/409) Flag to select ABCI client type.
+* (server) [#416](https://github.com/agoric-labs/cosmos-sdk/pull/416) Config entry to select ABCI client type.
 * (deps) [#412](https://github.com/agoric-labs/cosmos-sdk/pull/412) Bump iavl to v0.19.7
 * (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Unit tests and documentation for event history.
 

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -51,10 +51,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (server) [#409](https://github.com/agoric-labs/cosmos-sdk/pull/409) Flag to select ABCI client type.
 * (deps) [#412](https://github.com/agoric-labs/cosmos-sdk/pull/412) Bump iavl to v0.19.7
+* (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Unit tests and documentation for event history.
 
 ### Bug Fixes
 
 * (baseapp) [#413](https://github.com/agoric-labs/cosmos-sdk/pull/413) Ignore events from simulated transactions
+* (baseapp) [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) Avoid duplicates in event history.
 
 ## `v0.46.16-alpha.agoric.2.1` - 2024-03-08
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -266,6 +266,15 @@ func (app *BaseApp) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 // Regardless of tx execution outcome, the ResponseDeliverTx will contain relevant
 // gas execution context.
 func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliverTx) {
+	res = app.deliverTxWithoutEventHistory(req)
+	// When successful, remember event history.
+	if res.Code == sdkerrors.SuccessABCICode {
+		app.deliverState.eventHistory = append(app.deliverState.eventHistory, res.Events...)
+	}
+	return res
+}
+
+func (app *BaseApp) deliverTxWithoutEventHistory(req abci.RequestDeliverTx) (res abci.ResponseDeliverTx) {
 	gInfo := sdk.GasInfo{}
 	resultStr := "successful"
 
@@ -290,14 +299,12 @@ func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliv
 		return sdkerrors.ResponseDeliverTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, sdk.MarkEventsToIndex(anteEvents, app.indexEvents), app.trace)
 	}
 
-	events := sdk.MarkEventsToIndex(result.Events, app.indexEvents)
-	app.deliverState.eventHistory = append(app.deliverState.eventHistory, events...)
 	return abci.ResponseDeliverTx{
 		GasWanted: int64(gInfo.GasWanted), // TODO: Should type accept unsigned ints?
 		GasUsed:   int64(gInfo.GasUsed),   // TODO: Should type accept unsigned ints?
 		Log:       result.Log,
 		Data:      result.Data,
-		Events:    events,
+		Events:    sdk.MarkEventsToIndex(result.Events, app.indexEvents),
 	}
 }
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -203,9 +203,11 @@ func (app *BaseApp) EndBlock(req abci.RequestEndBlock) (res abci.ResponseEndBloc
 	}
 
 	if app.endBlocker != nil {
-		// Propagate the event history.
-		em := sdk.NewEventManagerWithHistory(app.deliverState.eventHistory)
-		res = app.endBlocker(app.deliverState.ctx.WithEventManager(em), req)
+		// [AGORIC] Propagate the event history.
+		enhancedEm := sdk.NewEventManagerWithHistory(app.deliverState.eventHistory)
+		enhancedCtx := app.deliverState.ctx.WithEventManager(enhancedEm)
+
+		res = app.endBlocker(enhancedCtx, req)
 		res.Events = sdk.MarkEventsToIndex(res.Events, app.indexEvents)
 	}
 
@@ -266,6 +268,8 @@ func (app *BaseApp) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 // Regardless of tx execution outcome, the ResponseDeliverTx will contain relevant
 // gas execution context.
 func (app *BaseApp) DeliverTx(req abci.RequestDeliverTx) (res abci.ResponseDeliverTx) {
+	// [AGORIC] Remember event history for successful deliveries.
+	// deliverTxWithoutEventHistory is the upstream cosmos-sdk DeliverTx.
 	res = app.deliverTxWithoutEventHistory(req)
 	// When successful, remember event history.
 	if res.Code == sdkerrors.SuccessABCICode {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -1,7 +1,6 @@
 package baseapp
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,6 +28,7 @@ const (
 	runTxModeDeliver                   // Deliver a transaction
 )
 
+// [AGORIC] Context keys for including TX hash and msg index.
 const (
 	TxHashContextKey   = sdk.ContextKey("tx-hash")
 	TxMsgIdxContextKey = sdk.ContextKey("tx-msg-idx")
@@ -435,7 +435,7 @@ func (app *BaseApp) setCheckState(header tmproto.Header) {
 	app.checkState = &state{
 		ms:           ms,
 		ctx:          sdk.NewContext(ms, header, true, app.logger).WithMinGasPrices(app.minGasPrices),
-		eventHistory: []abci.Event{},
+		eventHistory: []abci.Event{}, // [AGORIC]: start with an empty history.
 	}
 }
 
@@ -448,7 +448,7 @@ func (app *BaseApp) setDeliverState(header tmproto.Header) {
 	app.deliverState = &state{
 		ms:           ms,
 		ctx:          sdk.NewContext(ms, header, false, app.logger),
-		eventHistory: []abci.Event{},
+		eventHistory: []abci.Event{}, // [AGORIC]: start with an empty history.
 	}
 }
 
@@ -607,11 +607,13 @@ func (app *BaseApp) getContextForTx(mode runTxMode, txBytes []byte) sdk.Context 
 // cacheTxContext returns a new context based off of the provided context with
 // a branched multi-store.
 func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context, sdk.CacheMultiStore) {
+	// [AGORIC] Add Tx hash to the context if absent.
 	txHash, ok := ctx.Context().Value(TxHashContextKey).(string)
 	if !ok {
 		txHash = fmt.Sprintf("%X", tmhash.Sum(txBytes))
-		ctx = ctx.WithContext(context.WithValue(ctx.Context(), TxHashContextKey, txHash))
+		ctx = ctx.WithValue(TxHashContextKey, txHash)
 	}
+
 	ms := ctx.MultiStore()
 	// TODO: https://github.com/cosmos/cosmos-sdk/issues/2824
 	msCache := ms.CacheMultiStore()
@@ -796,7 +798,9 @@ func (app *BaseApp) runMsgs(ctx sdk.Context, msgs []sdk.Msg, mode runTxMode) (*s
 			err          error
 		)
 
-		msgCtx := ctx.WithContext(context.WithValue(ctx.Context(), TxMsgIdxContextKey, i))
+		// [AGORIC] Propagate the message index in the context.
+		msgCtx := ctx.WithValue(TxMsgIdxContextKey, i)
+
 		if handler := app.msgServiceRouter.Handler(msg); handler != nil {
 			// ADR 031 request type routing
 			msgResult, err = handler(msgCtx, msg)

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -1128,6 +1128,75 @@ func TestSimulateTx(t *testing.T) {
 	}
 }
 
+func TestEventHistory(t *testing.T) {
+	// generates events in the ante
+	anteKey := []byte("ante-key")
+	anteOpt := func(bapp *BaseApp) { bapp.SetAnteHandler(anteHandlerTxTest(t, capKey1, anteKey)) }
+
+	deliverKey := []byte("deliver-key")
+	routerOpt := func(bapp *BaseApp) {
+		r := sdk.NewRoute(routeMsgCounter, handlerMsgCounter(t, capKey1, deliverKey))
+		bapp.Router().AddRoute(r)
+	}
+
+	// expand setupBaseApp() here so we can override the EndBlocker before app is sealed
+	app := newBaseApp(t.Name(), anteOpt, routerOpt)
+	require.Equal(t, t.Name(), app.Name())
+
+	app.MountStores(capKey1, capKey2)
+	app.SetParamStore(&paramStore{db: dbm.NewMemDB()})
+
+	var history []abci.Event
+	app.SetEndBlocker(func(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
+		history = ctx.EventManager().GetABCIEventHistory()
+		return abci.ResponseEndBlock{}
+	})
+
+	// stores are mounted (seals the app)
+	err := app.LoadLatestVersion()
+	require.Nil(t, err)
+
+	app.InitChain(abci.RequestInitChain{})
+
+	// Create same codec used in txDecoder
+	cdc := codec.NewLegacyAmino()
+	registerTestCodec(cdc)
+
+	header := tmproto.Header{Height: int64(1)}
+	app.BeginBlock(abci.RequestBeginBlock{Header: header})
+
+	require.Zero(t, len(app.deliverState.eventHistory))
+
+	counter := int64(0)
+	tx := newTxCounter(counter, counter)
+	txBytes, err := cdc.Marshal(tx)
+	require.NoError(t, err)
+
+	// simulation returns events, but none in deliverState history
+	_, simResult, err := app.Simulate(txBytes)
+	require.NoError(t, err)
+	require.NotNil(t, simResult)
+	require.Zero(t, len(app.deliverState.eventHistory))
+	expectedEvents := simResult.Events
+	require.NotZero(t, len(expectedEvents))
+
+	// delivery results should be reflected in deliverState history
+	deliverResult := app.DeliverTx(abci.RequestDeliverTx{Tx: txBytes})
+	require.True(t, deliverResult.IsOK(), fmt.Sprintf("%v", deliverResult))
+	require.NotZero(t, len(app.deliverState.eventHistory))
+	// simResult events are not indexed, but should otherwise be the same as deliverResult events
+	for i, _ := range simResult.Events {
+		simResult.Events[i].Attributes[0].Index = true
+	}
+	require.Equal(t, expectedEvents, deliverResult.Events)
+	require.Equal(t, expectedEvents, app.deliverState.eventHistory)
+
+	// the deliverState event history should be passed to the end blocker in the context, then cleared
+	app.EndBlock(abci.RequestEndBlock{})
+	require.Zero(t, len(app.deliverState.eventHistory))
+	require.Equal(t, expectedEvents, history)
+}
+
 func TestRunInvalidTransaction(t *testing.T) {
 	anteOpt := func(bapp *BaseApp) {
 		bapp.SetAnteHandler(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (newCtx sdk.Context, err error) {

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -9,7 +9,7 @@ type state struct {
 	ms  sdk.CacheMultiStore
 	ctx sdk.Context
 	// eventHistory accumulates events returned by DeliverTx throughout a block.
-	// The accumulated events are passed to the EndBlocker in its context's
+	// [AGORIC] The accumulated events are passed to the EndBlocker in its context's
 	// EventManager ABCI event history, and the state's eventHistory is then cleared.
 	// Not used for modes or states other than delivery.
 	eventHistory []abci.Event

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -6,8 +6,12 @@ import (
 )
 
 type state struct {
-	ms           sdk.CacheMultiStore
-	ctx          sdk.Context
+	ms  sdk.CacheMultiStore
+	ctx sdk.Context
+	// eventHistory accumulates events returned by DeliverTx throughout a block.
+	// The accumulated events are passed to the EndBlocker in its context's
+	// EventManager ABCI event history, and the state's eventHistory is then cleared.
+	// Not used for modes or states other than delivery.
 	eventHistory []abci.Event
 }
 

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -14,8 +14,17 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
+// [AGORIC] Valid values for FlagAbciClientType
+const (
+	AbciClientTypeCommitting = "committing"
+	AbciClientTypeLocal      = "local"
+)
+
 const (
 	defaultMinGasPrices = ""
+
+	// DefaultABCIClientType defines the default ABCI client type to use with cometbft.
+	DefaultABCIClientType = AbciClientTypeCommitting // [AGORIC]
 
 	// DefaultAPIAddress defines the default address to bind the API server to.
 	DefaultAPIAddress = "tcp://0.0.0.0:1317"
@@ -93,6 +102,9 @@ type BaseConfig struct {
 
 	// IAVLLazyLoading enable/disable the lazy loading of iavl store.
 	IAVLLazyLoading bool `mapstructure:"iavl-lazy-loading"`
+
+	// ABCIClientType selects the type of ABCI client.
+	ABCIClientType string `mapstructure:"abci-client-type"`
 
 	// AppDBBackend defines the type of Database to use for the application and snapshots databases.
 	// An empty string indicates that the Tendermint config's DBBackend value should be used.
@@ -289,6 +301,7 @@ func DefaultConfig() *Config {
 			IAVLCacheSize:       781250, // 50 MB
 			IAVLDisableFastNode: false,
 			IAVLLazyLoading:     false,
+			ABCIClientType:      DefaultABCIClientType, // [AGORIC]
 			AppDBBackend:        "",
 		},
 		Telemetry: telemetry.Config{

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -82,6 +82,10 @@ iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 # Default is false.
 iavl-lazy-loading = {{ .BaseConfig.IAVLLazyLoading }}
 
+# ABCIClientType selects the type of ABCI client.
+# Default is "committing".
+abci-client-type = "{{ .BaseConfig.ABCIClientType }}"
+
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.
 # An empty string indicates that a fallback will be used.
 # First fallback is the deprecated compile-time types.DBBackend value.

--- a/server/start.go
+++ b/server/start.go
@@ -84,11 +84,6 @@ const (
 	flagGRPCWebAddress = "grpc-web.address"
 )
 
-const (
-	abciClientTypeCommitting = "committing"
-	abciClientTypeLocal      = "local"
-)
-
 // StartCmd runs the service passed in, either stand-alone or in-process with
 // Tendermint.
 func StartCmd(appCreator types.AppCreator, defaultNodeHome string) *cobra.Command {
@@ -149,18 +144,9 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 				})
 			}
 
-			abciClientType, err := cmd.Flags().GetString(FlagAbciClientType)
-			if err != nil {
-				return err
-			}
-			clientCreator, err := getAbciClientCreator(abciClientType)
-			if err != nil {
-				return err
-			}
-
 			// amino is needed here for backwards compatibility of REST routes
 			err = wrapCPUProfile(serverCtx, func() error {
-				return startInProcess(serverCtx, clientCtx, appCreator, clientCreator)
+				return startInProcess(serverCtx, clientCtx, appCreator)
 			})
 			errCode, ok := err.(ErrorCode)
 			if !ok {
@@ -210,7 +196,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
 	cmd.Flags().Bool(FlagDisableIAVLFastNode, false, "Disable fast node for IAVL tree")
-	cmd.Flags().String(FlagAbciClientType, abciClientTypeCommitting, fmt.Sprintf(`Type of ABCI client ("%s" or "%s")`, abciClientTypeCommitting, abciClientTypeLocal))
+	cmd.Flags().String(FlagAbciClientType, serverconfig.DefaultABCIClientType, fmt.Sprintf(`Type of ABCI client ("%s" or "%s")`, serverconfig.AbciClientTypeCommitting, serverconfig.AbciClientTypeLocal))
 
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)
@@ -273,7 +259,7 @@ func startStandAlone(ctx *Context, appCreator types.AppCreator) error {
 
 type abciClientCreator func(abcitypes.Application) proxy.ClientCreator
 
-func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.AppCreator, clientCreator abciClientCreator) error {
+func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.AppCreator) error {
 	cfg := ctx.Config
 	home := cfg.RootDir
 
@@ -305,6 +291,14 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 	}
 
 	genDocProvider := node.DefaultGenesisDocProviderFunc(cfg)
+
+	// [AGORIC] allow the ABCI client type to be configurable.
+	abciClientType := config.ABCIClientType
+	ctx.Logger.Info(fmt.Sprintf("ABCI client type: %s", abciClientType))
+	clientCreator, err := getAbciClientCreator(abciClientType)
+	if err != nil {
+		return err
+	}
 
 	var (
 		tmNode   *node.Node
@@ -520,11 +514,13 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 	return WaitForQuitSignals()
 }
 
+// getAbciClientCreator dispatches the client type to the right cometbft constructor.
+// [AGORIC] Allows us to disable committingClient.
 func getAbciClientCreator(abciClientType string) (abciClientCreator, error) {
 	switch abciClientType {
-	case abciClientTypeCommitting:
+	case serverconfig.AbciClientTypeCommitting:
 		return proxy.NewCommittingClientCreator, nil
-	case abciClientTypeLocal:
+	case serverconfig.AbciClientTypeLocal:
 		return proxy.NewLocalClientCreator, nil
 	}
 	return nil, fmt.Errorf(`unknown ABCI client type "%s"`, abciClientType)

--- a/types/events.go
+++ b/types/events.go
@@ -24,10 +24,14 @@ import (
 // EventManager implements a simple wrapper around a slice of Event objects that
 // can be emitted from.
 type EventManager struct {
-	events  Events
+	events Events
+	// history holds the events from all transactions delivered in a block
 	history []abci.Event
 }
 
+// NewEventManagerWithHistory returns a new event manager with empty events, but the given history
+// of events from all transactions delivered during a block.
+// This should be used to create the EventManager for use in EndBlockers.
 func NewEventManagerWithHistory(history []abci.Event) *EventManager {
 	return &EventManager{
 		events:  EmptyEvents(),
@@ -39,8 +43,8 @@ func NewEventManager() *EventManager {
 	return NewEventManagerWithHistory([]abci.Event{})
 }
 
-// GetEventHistory returns a deep copy of the ABCI events that have been
-// committed to thus far.
+// GetEventHistory returns a deep copy of the ABCI events history.
+// This should only be called in EndBlock processing.
 func (em *EventManager) GetABCIEventHistory() []abci.Event {
 	history := make([]abci.Event, len(em.history))
 	for i, event := range em.history {

--- a/types/events.go
+++ b/types/events.go
@@ -26,12 +26,13 @@ import (
 type EventManager struct {
 	events Events
 	// history holds the events from all transactions delivered in a block
+	// [AGORIC] Used to communicate the history through the context.
 	history []abci.Event
 }
 
-// NewEventManagerWithHistory returns a new event manager with empty events, but the given history
-// of events from all transactions delivered during a block.
-// This should be used to create the EventManager for use in EndBlockers.
+// NewEventManagerWithHistory returns a new event manager with empty events,
+// but seeded with the provided history of earlier events in the block.
+// [AGORIC] This should be used to create the EventManager for use in EndBlockers.
 func NewEventManagerWithHistory(history []abci.Event) *EventManager {
 	return &EventManager{
 		events:  EmptyEvents(),
@@ -43,8 +44,8 @@ func NewEventManager() *EventManager {
 	return NewEventManagerWithHistory([]abci.Event{})
 }
 
-// GetEventHistory returns a deep copy of the ABCI events history.
-// This should only be called in EndBlock processing.
+// GetABCIEventHistory returns a deep copy of the ABCI events history.
+// [AGORIC] This should only be called in EndBlock processing.
 func (em *EventManager) GetABCIEventHistory() []abci.Event {
 	history := make([]abci.Event, len(em.history))
 	for i, event := range em.history {

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -494,12 +494,14 @@ func (m *Manager) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) abci.R
 // child context with an event manager to aggregate events emitted from all
 // modules.
 func (m *Manager) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
-	// Reset the EventManager, preserving any existing event history.
-	em := ctx.EventManager()
-	if em == nil {
-		em = sdk.NewEventManager()
+	// [AGORIC] Reset the EventManager, preserving any existing event history.
+	eventHistory := []abci.Event{}
+	if oldEm := ctx.EventManager(); oldEm != nil {
+		eventHistory = oldEm.GetABCIEventHistory()
 	}
-	ctx = ctx.WithEventManager(sdk.NewEventManagerWithHistory(em.GetABCIEventHistory()))
+	em := sdk.NewEventManagerWithHistory(eventHistory)
+
+	ctx = ctx.WithEventManager(em)
 	validatorUpdates := []abci.ValidatorUpdate{}
 
 	for _, moduleName := range m.OrderEndBlockers {

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -494,6 +494,7 @@ func (m *Manager) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) abci.R
 // child context with an event manager to aggregate events emitted from all
 // modules.
 func (m *Manager) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) abci.ResponseEndBlock {
+	// Reset the EventManager, preserving any existing event history.
 	em := ctx.EventManager()
 	if em == nil {
 		em = sdk.NewEventManager()


### PR DESCRIPTION
## Description

Cherry-pick [#415](https://github.com/agoric-labs/cosmos-sdk/pull/415) and [#416](https://github.com/agoric-labs/cosmos-sdk/pull/416).

Update changelog.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
