### PR TITLE
build: cherry-pick commits for v0.46.16-alpha.agoric.2.4

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -45,6 +45,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * (auth, bank) Agoric/agoric-sdk#8989 Remove deprecated lien support
 
+## `v0.46.16-alpha.agoric.2.4` - 2024-04-19
+
+### Improvements
+
+* (server) [#419](https://github.com/agoric-labs/cosmos-sdk/pull/419) More unit tests for flag vs toml precedence for ABCI client type.
+
 ## `v0.46.16-alpha.agoric.2.3` - 2024-04-17
 
 ### Improvements

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -104,6 +104,9 @@ type BaseConfig struct {
 	IAVLLazyLoading bool `mapstructure:"iavl-lazy-loading"`
 
 	// ABCIClientType selects the type of ABCI client.
+	// Valid settings are "committing" (default) or "local".
+	// The committing client allows greater query parallelism,
+	// but the local client is more defensive.
 	ABCIClientType string `mapstructure:"abci-client-type"`
 
 	// AppDBBackend defines the type of Database to use for the application and snapshots databases.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -83,7 +83,9 @@ iavl-disable-fastnode = {{ .BaseConfig.IAVLDisableFastNode }}
 iavl-lazy-loading = {{ .BaseConfig.IAVLLazyLoading }}
 
 # ABCIClientType selects the type of ABCI client.
-# Default is "committing".
+# Valid settings are "committing" (default) or "local".
+# The committing client allows greater query parallelism,
+# but the local client is more defensive.
 abci-client-type = "{{ .BaseConfig.ABCIClientType }}"
 
 # AppDBBackend defines the database backend type to use for the application and snapshots DBs.

--- a/server/start_test.go
+++ b/server/start_test.go
@@ -1,9 +1,17 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/spf13/cobra"
+	tmcfg "github.com/tendermint/tendermint/config"
 )
 
 func TestAbciClientType(t *testing.T) {
@@ -40,6 +48,86 @@ func TestAbciClientType(t *testing.T) {
 						t.Errorf(`want creator "%s", got "%s"`, tt.creatorName, creatorName)
 					}
 				}
+			}
+		})
+	}
+}
+
+var errCancelledInPreRun = errors.New("cancelled in prerun")
+
+func TestAbciClientPrecedence(t *testing.T) {
+	for i, tt := range []struct {
+		flag, toml, want string
+	}{
+		{
+			want: "committing",
+		},
+		{
+			flag: "foo",
+			want: "foo",
+		},
+		{
+			toml: "foo",
+			want: "foo",
+		},
+		{
+			flag: "foo",
+			toml: "bar",
+			want: "foo",
+		},
+	} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			tempDir := t.TempDir()
+			err := os.Mkdir(path.Join(tempDir, "config"), os.ModePerm)
+			if err != nil {
+				t.Fatalf("creating config dir failed: %v", err)
+			}
+			appTomlPath := path.Join(tempDir, "config", "app.toml")
+
+			cmd := StartCmd(nil, tempDir)
+
+			if tt.flag != "" {
+				err = cmd.Flags().Set(FlagAbciClientType, tt.flag)
+				if err != nil {
+					t.Fatalf(`failed setting flag to "%s": %v`, tt.flag, err)
+				}
+			}
+
+			if tt.toml != "" {
+				writer, err := os.Create(appTomlPath)
+				if err != nil {
+					t.Fatalf(`failed creating "%s": %v`, appTomlPath, err)
+				}
+				_, err = writer.WriteString(fmt.Sprintf("%s = \"%s\"\n", FlagAbciClientType, tt.toml))
+				if err != nil {
+					t.Fatalf(`failed writing to app.toml: %v`, err)
+				}
+				err = writer.Close()
+				if err != nil {
+					t.Fatalf(`failed closing app.toml: %v`, err)
+				}
+			}
+
+			// Compare to tests in util_test.go
+			cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+				err := InterceptConfigsPreRunHandler(cmd, "", nil, tmcfg.DefaultConfig())
+				if err != nil {
+					return err
+				}
+				return errCancelledInPreRun
+			}
+
+			serverCtx := NewDefaultContext()
+			ctx := context.WithValue(context.Background(), ServerContextKey, serverCtx)
+			err = cmd.ExecuteContext(ctx)
+			if err != errCancelledInPreRun {
+				t.Fatal(err)
+			}
+
+			gotClientType := serverCtx.Viper.GetString(FlagAbciClientType)
+
+			if gotClientType != tt.want {
+				t.Errorf(`want client type "%s", got "%s"`, tt.want, gotClientType)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Cherry-pick #419 and update CHANGELOG-Agoric.md.

Refs: Agoric/agoric-sdk#9224

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] confirmed all author checklist items have been addressed 
- [x] reviewed state machine logic
- [x] reviewed API design and naming
- [x] reviewed documentation is accurate
- [x] reviewed tests and test coverage
- [x] manually tested (if applicable)
