### PR TITLE
fix(client): race- and timeout-free `-bblock`

### DIFF
--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -2,14 +2,17 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
+	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/mempool"
 	tmtypes "github.com/cometbft/cometbft/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -27,6 +30,11 @@ func (ctx Context) BroadcastTx(txBytes []byte) (res *sdk.TxResponse, err error) 
 
 	case flags.BroadcastAsync:
 		res, err = ctx.BroadcastTxAsync(txBytes)
+
+	// [AGORIC]: We provide BroadcastTxCommit to ensure that the transaction is
+	// included in a block.
+	case flags.BroadcastBlock:
+		res, err = ctx.BroadcastTxCommit(txBytes)
 
 	default:
 		return nil, fmt.Errorf("unsupported return type %s; supported types: sync, async", ctx.BroadcastMode)
@@ -76,6 +84,84 @@ func CheckTendermintError(err error, tx tmtypes.Tx) *sdk.TxResponse {
 	default:
 		return nil
 	}
+}
+
+// BroadcastTxCommit broadcasts transaction bytes to a Tendermint node and
+// waits for a commit. An error is only returned if there is no RPC node
+// connection or if broadcasting fails.
+//
+// [AGORIC]: This function subscribes to the transaction's inclusion in a block,
+// and then use BroadcastTxSync to broadcast the transaction.  This will block
+// potentially forever if the transaction is never included in a block.  And so,
+// it is up to the caller to ensure that proper timeout/retry logic is
+// implemented.
+func (ctx Context) BroadcastTxCommit(txBytes []byte) (*sdk.TxResponse, error) {
+	node, err := ctx.GetNode()
+	if err != nil {
+		return nil, err
+	}
+
+	cctx := context.Background()
+	// This is where we would allow for a timeout on the commit.  We want to
+	// default to no timeout, and accept a specific timeout as a CLI flag (as is
+	// done in v0.50), but hardcoding an arbitrary timeout (like in v0.47 and
+	// before) is just rude.
+	/*
+		cctx, cancel := context.WithTimeout(cctx, <specified time.Duration>)
+		defer cancel()
+	*/
+
+	// To prevent races, first subscribe to a query for the transaction's
+	// inclusion in a block.  Clean up when we are done.
+	txHash := fmt.Sprintf("%X", tmhash.Sum(txBytes))
+	waitTxCh := WaitTx(cctx, ctx.NodeURI, txHash)
+
+	// Broadcast the transaction.
+	res, err := node.BroadcastTxSync(context.Background(), txBytes)
+	if errRes := CheckTendermintError(err, txBytes); errRes != nil {
+		return errRes, nil
+	}
+
+	// Check for an error in the broadcast.
+	syncRes := sdk.NewResponseFormatBroadcastTx(res)
+	if syncRes.Code != 0 {
+		return syncRes, err
+	}
+
+	// Wait for the transaction to be committed.
+	waitTx := <-waitTxCh
+
+	// Process the event data and return the commit response.
+	if evt := waitTx.BlockInclusion; evt != nil {
+		evtHash := fmt.Sprintf("%X", tmtypes.Tx(evt.Tx).Hash())
+		if evtHash != txHash {
+			return syncRes, fmt.Errorf("tx hash did not match: got %s, expected %s", evtHash, txHash)
+		}
+
+		parsedLogs, parseErr := sdk.ParseABCILogs(evt.Result.Log)
+		commitRes := &sdk.TxResponse{
+			TxHash:    evtHash,
+			Height:    evt.Height,
+			Codespace: evt.Result.Codespace,
+			Code:      evt.Result.Code,
+			Data:      strings.ToUpper(hex.EncodeToString(evt.Result.Data)),
+			RawLog:    evt.Result.Log,
+			Logs:      parsedLogs,
+			Info:      evt.Result.Info,
+			GasWanted: evt.Result.GasWanted,
+			GasUsed:   evt.Result.GasUsed,
+			Events:    evt.Result.Events,
+		}
+		if !evt.Result.IsOK() {
+			return commitRes, fmt.Errorf("unexpected result code %d", evt.Result.Code)
+		}
+		return commitRes, parseErr
+	}
+
+	if waitTx.Err != nil {
+		return syncRes, waitTx.Err
+	}
+	return syncRes, sdkerrors.ErrLogic.Wrapf("tx block inclusion not detected")
 }
 
 // BroadcastTxSync broadcasts transaction bytes to a Tendermint node
@@ -136,7 +222,79 @@ func normalizeBroadcastMode(mode tx.BroadcastMode) string {
 		return "async"
 	case tx.BroadcastMode_BROADCAST_MODE_SYNC:
 		return "sync"
+	// [AGORIC]: We reimplemented block mode as a wrapper for wait-tx.
+	case tx.BroadcastMode_BROADCAST_MODE_BLOCK:
+		return "block"
 	default:
 		return "unspecified"
 	}
+}
+
+type WaitTxResult struct {
+	BlockInclusion *tmtypes.EventDataTx
+	Err            error
+}
+
+// [AGORIC]: WaitTx subscribes to the transaction result event raised
+// when the transaction matching the hash either errors or is included in a block.
+// It returns a channel for the response.
+func WaitTx(ctx context.Context, nodeURI, hash string) <-chan WaitTxResult {
+	// Guestimate the capacity of the deferrals, no big deal if we're wrong
+	deferrals := make([]func(), 0, 2)
+	resultCh := make(chan WaitTxResult, 1)
+
+	// We wrap the return results in a function to ensure that we will run the
+	// deferrals only when we are producing the result channel.
+	result := func(res *tmtypes.EventDataTx, err error) <-chan WaitTxResult {
+		// Ensure our deferrals are run before the caller gets its hands on the
+		// result channel.
+		defer func() {
+			for i := len(deferrals) - 1; i >= 0; i-- {
+				deferrals[i]()
+			}
+		}()
+		resultCh <- WaitTxResult{res, err}
+		close(resultCh)
+		return resultCh
+	}
+
+	// We track our own deferrals to ensure that we clean up the client and
+	// subscription regardless of whether we return synchronously, or from within
+	// the goroutine.
+	deferral := func(deferred func()) {
+		deferrals = append(deferrals, deferred)
+	}
+
+	c, err := rpchttp.New(nodeURI, "/websocket")
+	if err != nil {
+		return result(nil, err)
+	}
+	if err := c.Start(); err != nil {
+		return result(nil, err)
+	}
+	deferral(func() { c.Stop() }) //nolint:errcheck // ignore stop error
+
+	// Subscribe to the tx event.
+	query := fmt.Sprintf("%s='%s' AND %s='%s'", tmtypes.EventTypeKey, tmtypes.EventTx, tmtypes.TxHashKey, hash)
+	const subscriber = "subscriber"
+	eventCh, err := c.Subscribe(ctx, subscriber, query)
+	if err != nil {
+		return result(nil, fmt.Errorf("failed to subscribe to tx: %w", err))
+	}
+	deferral(func() { c.UnsubscribeAll(context.Background(), subscriber) }) //nolint:errcheck // ignore unsubscribe error
+
+	// Since we're now fully subscribed, we can return the channel and wait for
+	// the event or context deadline in a background goroutine.
+	go func() <-chan WaitTxResult {
+		select {
+		case evt := <-eventCh:
+			if txe, ok := evt.Data.(tmtypes.EventDataTx); ok {
+				return result(&txe, nil)
+			}
+			return result(nil, sdkerrors.ErrLogic.Wrapf("unsupported event data type %T", evt.Data))
+		case <-ctx.Done():
+			return result(nil, sdkerrors.ErrLogic.Wrapf("timed out waiting for event"))
+		}
+	}()
+	return resultCh
 }

--- a/client/broadcast_test.go
+++ b/client/broadcast_test.go
@@ -21,6 +21,10 @@ type MockClient struct {
 	err error
 }
 
+func (c MockClient) BroadcastTxCommit(ctx context.Context, tx tmtypes.Tx) (*coretypes.ResultBroadcastTxCommit, error) {
+	return nil, c.err
+}
+
 func (c MockClient) BroadcastTxAsync(ctx context.Context, tx tmtypes.Tx) (*coretypes.ResultBroadcastTx, error) {
 	return nil, c.err
 }
@@ -47,6 +51,7 @@ func TestBroadcastError(t *testing.T) {
 	modes := []string{
 		flags.BroadcastAsync,
 		flags.BroadcastSync,
+		flags.BroadcastBlock,
 	}
 
 	txBytes := []byte{0xA, 0xB}

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -28,6 +28,9 @@ const (
 	// BroadcastAsync defines a tx broadcasting mode where the client returns
 	// immediately.
 	BroadcastAsync = "async"
+	// [AGORIC]: BroadcastBlock is an emulated compatibility mode which uses
+	// event subscription to wait until the tx is committed in a block.
+	BroadcastBlock = "block"
 
 	// SignModeDirect is the value of the --sign-mode flag for SIGN_MODE_DIRECT
 	SignModeDirect = "direct"

--- a/client/rpc/tx.go
+++ b/client/rpc/tx.go
@@ -3,11 +3,9 @@ package rpc
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"time"
 
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/spf13/cobra"
@@ -96,41 +94,39 @@ func QueryEventForTxCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			c, err := rpchttp.New(clientCtx.NodeURI, "/websocket")
-			if err != nil {
-				return err
-			}
-			if err := c.Start(); err != nil {
-				return err
-			}
-			defer c.Stop() //nolint:errcheck // ignore stop error
 
+			hash := args[0]
+
+			// XXX: We use a hardcoded 15 second timeout for compatibility with v0.47,
+			// but this will be configurable sometime in v0.50.
+			// You can use Agoric's -bblock if you don't want any timeout.
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
 			defer cancel()
 
-			hash := args[0]
-			query := fmt.Sprintf("%s='%s' AND %s='%s'", tmtypes.EventTypeKey, tmtypes.EventTx, tmtypes.TxHashKey, hash)
-			const subscriber = "subscriber"
-			eventCh, err := c.Subscribe(ctx, subscriber, query)
-			if err != nil {
-				return fmt.Errorf("failed to subscribe to tx: %w", err)
-			}
-			defer c.UnsubscribeAll(context.Background(), subscriber) //nolint:errcheck // ignore unsubscribe error
-
-			select {
-			case evt := <-eventCh:
-				if txe, ok := evt.Data.(tmtypes.EventDataTx); ok {
-					res := &coretypes.ResultBroadcastTxCommit{
-						DeliverTx: txe.Result,
-						Hash:      tmtypes.Tx(txe.Tx).Hash(),
-						Height:    txe.Height,
-					}
-					return clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(res))
+			// We block here until the event is received, but only if the above
+			// context timeout doesn't happen first.
+			waitTx := <-client.WaitTx(ctx, clientCtx.NodeURI, hash)
+			if evt := waitTx.BlockInclusion; evt != nil {
+				// There was block inclusion, so print the event.
+				res := &coretypes.ResultBroadcastTxCommit{
+					DeliverTx: evt.Result,
+					Hash:      tmtypes.Tx(evt.Tx).Hash(),
+					Height:    evt.Height,
 				}
-			case <-ctx.Done():
-				return errors.ErrLogic.Wrapf("timed out waiting for event, the transaction could have already been included or wasn't yet included")
+
+				err = clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(res))
 			}
-			return nil
+
+			// Check for waiting errors, if any.
+			if waitTx.Err != nil {
+				if ctx.Err() == context.DeadlineExceeded {
+					return errors.ErrLogic.Wrapf("timed out waiting for event, the transaction could have already been included or wasn't yet included")
+				}
+				return waitTx.Err
+			}
+
+			// Propagate the printing error, if any.
+			return err
 		},
 	}
 

--- a/tests/e2e/bank/suite.go
+++ b/tests/e2e/bank/suite.go
@@ -444,7 +444,7 @@ func (s *E2ETestSuite) TestNewSendTxCmd() {
 			),
 			[]string{
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
-				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastSync),
+				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
 				fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(s.cfg.BondDenom, sdk.NewInt(10))).String()),
 			},
 			false, 0, &sdk.TxResponse{},

--- a/x/upgrade/types/query.pb.go
+++ b/x/upgrade/types/query.pb.go
@@ -778,6 +778,7 @@ func _Query_Authority_Handler(srv interface{}, ctx context.Context, dec func(int
 	return interceptor(ctx, in, info, handler)
 }
 
+var Query_serviceDesc = _Query_serviceDesc
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cosmos.upgrade.v1beta1.Query",
 	HandlerType: (*QueryServer)(nil),

--- a/x/upgrade/types/tx.pb.go
+++ b/x/upgrade/types/tx.pb.go
@@ -366,6 +366,7 @@ func _Msg_CancelUpgrade_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+var Msg_serviceDesc = _Msg_serviceDesc
 var _Msg_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "cosmos.upgrade.v1beta1.Msg",
 	HandlerType: (*MsgServer)(nil),


### PR DESCRIPTION
closes: https://github.com/Agoric/agoric-sdk/issues/9016

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->
This PR is designed to avoid breaking compatibility with scripts and programs that rely on the old `-bblock` flag.  The old `-bblock` relied on CometBFT's `/tx_broadcast_commit` endpoint, with its arbitrary, implicit 30 second timeout for block inclusion.  Since the `-bblock` flag has been removed from v0.47, this PR reimplements the `tx -bblock` flag with a subscribe(txhash)-broadcast(sync)-wait(txhash-inclusion) and no timeout.

It is useful also to provide the subscribe/wait mechanism as a separate CLI command, and indeed, there are features in v0.47 (`agd query event-query-tx-for $(agd tx ... | jq .txHash)`, though with a hardcoded 15 second wait) and v0.50 (`agd tx ... | agd query wait-tx` ) that attempt to do just that.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
