### PR TITLE
fix(client): make `appd query wait-tx` robust

### DIFF
--- a/.github/workflows/changelog-reminder.yml
+++ b/.github/workflows/changelog-reminder.yml
@@ -16,4 +16,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mskelton/changelog-reminder-action@v3
         with:
+          changelogRegex: "CHANGELOG\\.md|CHANGELOG-Agoric\\.md"
           message: "@${{ github.actor }} your pull request is missing a changelog!"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,20 +4,13 @@ run:
   sort-results: true
   allow-parallel-runners: true
   exclude-dir: testutil/testdata
-  skip-files:
-    - server/grpc/gogoreflection/fix_registration.go
-    - "fix_registration.go"
-    - "x/bank/migrations/v4/gen_state_test.go"
-    - ".*\\.pb\\.go$"
-    - ".*\\.pb\\.gw\\.go$"
-    - ".*\\.pulsar\\.go$"
 
 linters:
   disable-all: true
   enable:
     # - depguard
     - dogsled
-    - exportloopref
+    # - exportloopref
     - goconst
     - gocritic
     - gci
@@ -38,6 +31,13 @@ linters:
     - unused
 
 issues:
+  exclude-files:
+    - server/grpc/gogoreflection/fix_registration.go
+    - "fix_registration.go"
+    - "x/bank/migrations/v4/gen_state_test.go"
+    - ".*\\.pb\\.go$"
+    - ".*\\.pb\\.gw\\.go$"
+    - ".*\\.pulsar\\.go$"
   exclude-rules:
     - text: "Use of weak random number generator"
       linters:

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -37,6 +37,18 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+Upgrade to v0.50.13 of the Cosmos SDK, with Agoric changes preserved.
+
+### Bug Fixes
+
+* (client) [#441](https://github.com/agoric-labs/cosmos-sdk/pull/441)  Make `appd query wait-tx` robust by retrying if the tx hash could not be queried, but the Tx event has already passed.
+
+### `v0.47.17-alpha.agoric.1` - 2025-03-25
+
+Upgrade to v0.47.17 of the Cosmos SDK, with Agoric changes preserved.
+
+## `v0.46.16-alpha.agoric.2.5` - 2024-12-16
+
 ### API Breaking
 
 * (auth, bank) Agoric/agoric-sdk#8989 Remove deprecated lien support

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -161,7 +161,7 @@ func (app *BaseApp) Query(_ context.Context, req *abci.RequestQuery) (resp *abci
 	}()
 
 	// when a client did not provide a query height, manually inject the latest
-	//[AGORIC] sanity check required for parallel Query https://github.com/agoric-labs/cosmos-sdk/pull/111
+	// [AGORIC] sanity check required for parallel Query https://github.com/agoric-labs/cosmos-sdk/pull/111
 	lastHeight := app.LastBlockHeight()
 	if req.Height == 0 {
 		req.Height = lastHeight
@@ -950,7 +950,6 @@ func (app *BaseApp) Commit() (*abci.ResponseCommit, error) {
 		app.SnapshotManager().SnapshotIfApplicable(snapshotHeight)
 	}
 	return res, err
-
 }
 
 // CommitWithoutSnapshot is like Commit but instead of starting the snapshot goroutine
@@ -1002,7 +1001,7 @@ func (app *BaseApp) CommitWithoutSnapshot() (*abci.ResponseCommit, int64, error)
 
 	var snapshotHeight int64
 	// [AGORIC] In case it should not take snapshot snapshotHeight
-	//will be equal to zero preventing the snapshot from being taken
+	// will be equal to zero preventing the snapshot from being taken
 	if app.snapshotManager.ShouldTakeSnapshot(header.Height) {
 		snapshotHeight = header.Height
 	}

--- a/baseapp/state.go
+++ b/baseapp/state.go
@@ -3,11 +3,11 @@ package baseapp
 import (
 	"sync"
 
+	abci "github.com/cometbft/cometbft/abci/types"
+
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	abci "github.com/cometbft/cometbft/abci/types"
 )
 
 type state struct {

--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/mempool"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -91,6 +93,95 @@ func CheckCometError(err error, tx cmttypes.Tx) *sdk.TxResponse {
 	}
 }
 
+// WaitTxAsBroadcastTxCommit waits for a transaction to be included in a block by subscribing
+// to the CometBFT WebSocket connection and waiting for a transaction event with
+// the given hash. It returns a ResultBroadcastTxCommit which contains the
+// transaction result and the block height in which the transaction was included.
+func (ctx Context) WaitTxAsBroadcastTxCommit(cctx context.Context, txSubmitted func() (*sdk.TxResponse, []byte, error)) (*coretypes.ResultBroadcastTxCommit, error) {
+	c, err := rpchttp.New(ctx.NodeURI, "/websocket")
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Start(); err != nil {
+		return nil, err
+	}
+	defer c.Stop() //nolint:errcheck // ignore stop error
+
+	var hash []byte
+	submitRes, hash, err := txSubmitted()
+	if err != nil {
+		return nil, err
+	}
+	if submitRes != nil && submitRes.Code != 0 {
+		return nil, sdkerrors.ErrLogic.Wrapf("transaction %X submission failed with code %d: %s", hash, submitRes.Code, submitRes.RawLog)
+	}
+	txHash := fmt.Sprintf("%X", hash)
+
+	// subscribe to websocket events
+	blockQuery := fmt.Sprintf("%s='%s'", cmttypes.EventTypeKey, cmttypes.EventNewBlockHeader)
+	const subscriber = "subscriber"
+	blockEventCh, err := c.Subscribe(cctx, subscriber, blockQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to new blocks: %w", err)
+	}
+	txQuery := fmt.Sprintf("%s='%s' AND %s='%s'", cmttypes.EventTypeKey, cmttypes.EventTx, cmttypes.TxHashKey, txHash)
+	txEventCh, err := c.Subscribe(cctx, subscriber, txQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to subscribe to tx: %w", err)
+	}
+	defer c.UnsubscribeAll(context.Background(), subscriber) //nolint:errcheck // ignore unsubscribe error
+
+	for err = cctx.Err(); err == nil; err = cctx.Err() {
+		// return immediately if tx is already included in a block
+		if res, err := c.Tx(cctx, hash, false); err == nil {
+			res := &coretypes.ResultBroadcastTxCommit{
+				TxResult: res.TxResult,
+				Hash:     res.Hash,
+				Height:   res.Height,
+			}
+			return res, nil
+		}
+
+		// tx not yet included in a block, wait for new blocks on websocket or context timeout
+		select {
+		case evt := <-txEventCh:
+			if txe, ok := evt.Data.(cmttypes.EventDataTx); ok {
+				evtHashBytes := cmttypes.Tx(txe.Tx).Hash()
+				evtHash := fmt.Sprintf("%X", evtHashBytes)
+				if evtHash == txHash {
+					return &coretypes.ResultBroadcastTxCommit{
+						TxResult: txe.Result,
+						Hash:     evtHashBytes,
+						Height:   txe.Height,
+					}, nil
+				}
+			}
+		case _, ok := <-blockEventCh:
+			if !ok {
+				return nil, sdkerrors.ErrIO.Wrapf("could not find transaction %X included in a block; subscription closed", hash)
+			}
+			// Poll again to check if the transaction is included in the new block.
+		case <-cctx.Done():
+			// If the context is done, exit the loop via the ctx.Err() condition.
+		}
+	}
+
+	return nil, sdkerrors.ErrLogic.Wrapf("could not find transaction %X included in a block: %s", hash, err.Error())
+}
+
+// WaitTx waits for a transaction to be included in a block by subscribing
+// to the CometBFT WebSocket connection and waiting for a transaction event with
+// the given hash. It returns a TxResponse which contains the transaction result
+// and the block height in which the transaction was included.
+func (ctx Context) WaitTx(cctx context.Context, ensureTxSubmitted func() (*sdk.TxResponse, []byte, error)) (*sdk.TxResponse, error) {
+	res, err := ctx.WaitTxAsBroadcastTxCommit(cctx, ensureTxSubmitted)
+	if err != nil {
+		return nil, err
+	}
+
+	return newResponseFormatBroadcastTxCommit(res), nil
+}
+
 // BroadcastTxCommit broadcasts transaction bytes to a Tendermint node and
 // waits for a commit. An error is only returned if there is no RPC node
 // connection or if broadcasting fails.
@@ -116,58 +207,94 @@ func (ctx Context) BroadcastTxCommit(txBytes []byte) (*sdk.TxResponse, error) {
 		defer cancel()
 	*/
 
+	txSubmitted := func() (*sdk.TxResponse, []byte, error) {
+		// Broadcast the transaction.
+		hash := tmhash.Sum(txBytes)
+
+		res, err := node.BroadcastTxSync(context.Background(), txBytes)
+		if errRes := CheckCometError(err, txBytes); errRes != nil {
+			return errRes, hash, nil
+		}
+
+		// Check for an error in the broadcast.
+		syncRes := sdk.NewResponseFormatBroadcastTx(res)
+		return syncRes, hash, err
+	}
+
 	// To prevent races, first subscribe to a query for the transaction's
 	// inclusion in a block.  Clean up when we are done.
-	txHash := fmt.Sprintf("%X", tmhash.Sum(txBytes))
-	waitTxCh := WaitTx(cctx, ctx.NodeURI, txHash)
-
-	// Broadcast the transaction.
-	res, err := node.BroadcastTxSync(context.Background(), txBytes)
-	if errRes := CheckTendermintError(err, txBytes); errRes != nil {
-		return errRes, nil
+	res, err := ctx.WaitTx(cctx, txSubmitted)
+	if err != nil {
+		return nil, err
 	}
 
-	// Check for an error in the broadcast.
-	syncRes := sdk.NewResponseFormatBroadcastTx(res)
-	if syncRes.Code != 0 {
-		return syncRes, err
+	return res, nil
+}
+
+func newTxResponseCheckTx(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
+	if res == nil {
+		return nil
 	}
 
-	// Wait for the transaction to be committed.
-	waitTx := <-waitTxCh
-
-	// Process the event data and return the commit response.
-	if evt := waitTx.BlockInclusion; evt != nil {
-		evtHash := fmt.Sprintf("%X", cmttypes.Tx(evt.Tx).Hash())
-		if evtHash != txHash {
-			return syncRes, fmt.Errorf("tx hash did not match: got %s, expected %s", evtHash, txHash)
-		}
-
-		parsedLogs, _ := sdk.ParseABCILogs(evt.Result.Log)
-
-		commitRes := &sdk.TxResponse{
-			TxHash:    evtHash,
-			Height:    evt.Height,
-			Codespace: evt.Result.Codespace,
-			Code:      evt.Result.Code,
-			Data:      strings.ToUpper(hex.EncodeToString(evt.Result.Data)),
-			RawLog:    evt.Result.Log,
-			Logs:      parsedLogs,
-			Info:      evt.Result.Info,
-			GasWanted: evt.Result.GasWanted,
-			GasUsed:   evt.Result.GasUsed,
-			Events:    evt.Result.Events,
-		}
-		if !evt.Result.IsOK() {
-			return commitRes, fmt.Errorf("unexpected result code %d", evt.Result.Code)
-		}
-		return commitRes, nil
+	var txHash string
+	if res.Hash != nil {
+		txHash = res.Hash.String()
 	}
 
-	if waitTx.Err != nil {
-		return syncRes, waitTx.Err
+	parsedLogs, _ := sdk.ParseABCILogs(res.CheckTx.Log)
+
+	return &sdk.TxResponse{
+		Height:    res.Height,
+		TxHash:    txHash,
+		Codespace: res.CheckTx.Codespace,
+		Code:      res.CheckTx.Code,
+		Data:      strings.ToUpper(hex.EncodeToString(res.CheckTx.Data)),
+		RawLog:    res.CheckTx.Log,
+		Logs:      parsedLogs,
+		Info:      res.CheckTx.Info,
+		GasWanted: res.CheckTx.GasWanted,
+		GasUsed:   res.CheckTx.GasUsed,
+		Events:    res.CheckTx.Events,
 	}
-	return syncRes, sdkerrors.ErrLogic.Wrapf("tx block inclusion not detected")
+}
+
+func newTxResponseDeliverTx(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
+	if res == nil {
+		return nil
+	}
+
+	var txHash string
+	if res.Hash != nil {
+		txHash = res.Hash.String()
+	}
+
+	parsedLogs, _ := sdk.ParseABCILogs(res.TxResult.Log)
+
+	return &sdk.TxResponse{
+		Height:    res.Height,
+		TxHash:    txHash,
+		Codespace: res.TxResult.Codespace,
+		Code:      res.TxResult.Code,
+		Data:      strings.ToUpper(hex.EncodeToString(res.TxResult.Data)),
+		RawLog:    res.TxResult.Log,
+		Logs:      parsedLogs,
+		Info:      res.TxResult.Info,
+		GasWanted: res.TxResult.GasWanted,
+		GasUsed:   res.TxResult.GasUsed,
+		Events:    res.TxResult.Events,
+	}
+}
+
+func newResponseFormatBroadcastTxCommit(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
+	if res == nil {
+		return nil
+	}
+
+	if !res.CheckTx.IsOK() {
+		return newTxResponseCheckTx(res)
+	}
+
+	return newTxResponseDeliverTx(res)
 }
 
 // BroadcastTxSync broadcasts transaction bytes to a Tendermint node
@@ -234,73 +361,4 @@ func normalizeBroadcastMode(mode tx.BroadcastMode) string {
 	default:
 		return "unspecified"
 	}
-}
-
-type WaitTxResult struct {
-	BlockInclusion *cmttypes.EventDataTx
-	Err            error
-}
-
-// [AGORIC]: WaitTx subscribes to the transaction result event raised
-// when the transaction matching the hash either errors or is included in a block.
-// It returns a channel for the response.
-func WaitTx(ctx context.Context, nodeURI, hash string) <-chan WaitTxResult {
-	// Guestimate the capacity of the deferrals, no big deal if we're wrong
-	deferrals := make([]func(), 0, 2)
-	resultCh := make(chan WaitTxResult, 1)
-
-	// We wrap the return results in a function to ensure that we will run the
-	// deferrals only when we are producing the result channel.
-	result := func(res *cmttypes.EventDataTx, err error) <-chan WaitTxResult {
-		// Ensure our deferrals are run before the caller gets its hands on the
-		// result channel.
-		defer func() {
-			for i := len(deferrals) - 1; i >= 0; i-- {
-				deferrals[i]()
-			}
-		}()
-		resultCh <- WaitTxResult{res, err}
-		close(resultCh)
-		return resultCh
-	}
-
-	// We track our own deferrals to ensure that we clean up the client and
-	// subscription regardless of whether we return synchronously, or from within
-	// the goroutine.
-	deferral := func(deferred func()) {
-		deferrals = append(deferrals, deferred)
-	}
-
-	c, err := rpchttp.New(nodeURI, "/websocket")
-	if err != nil {
-		return result(nil, err)
-	}
-	if err := c.Start(); err != nil {
-		return result(nil, err)
-	}
-	deferral(func() { c.Stop() }) //nolint:errcheck // ignore stop error
-
-	// Subscribe to the tx event.
-	query := fmt.Sprintf("%s='%s' AND %s='%s'", cmttypes.EventTypeKey, cmttypes.EventTx, cmttypes.TxHashKey, hash)
-	const subscriber = "subscriber"
-	eventCh, err := c.Subscribe(ctx, subscriber, query)
-	if err != nil {
-		return result(nil, fmt.Errorf("failed to subscribe to tx: %w", err))
-	}
-	deferral(func() { c.UnsubscribeAll(context.Background(), subscriber) }) //nolint:errcheck // ignore unsubscribe error
-
-	// Since we're now fully subscribed, we can return the channel and wait for
-	// the event or context deadline in a background goroutine.
-	go func() <-chan WaitTxResult {
-		select {
-		case evt := <-eventCh:
-			if txe, ok := evt.Data.(cmttypes.EventDataTx); ok {
-				return result(&txe, nil)
-			}
-			return result(nil, sdkerrors.ErrLogic.Wrapf("unsupported event data type %T", evt.Data))
-		case <-ctx.Done():
-			return result(nil, sdkerrors.ErrLogic.Wrapf("timed out waiting for event"))
-		}
-	}()
-	return resultCh
 }

--- a/client/broadcast.go
+++ b/client/broadcast.go
@@ -8,13 +8,12 @@ import (
 
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/mempool"
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	cmttypes "github.com/cometbft/cometbft/types"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"

--- a/client/rpc/tx.go
+++ b/client/rpc/tx.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	coretypes "github.com/cometbft/cometbft/rpc/core/types"
-	tmtypes "github.com/cometbft/cometbft/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -21,78 +19,12 @@ import (
 
 const TimeoutFlag = "timeout"
 
-func newTxResponseCheckTx(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
-	if res == nil {
-		return nil
-	}
-
-	var txHash string
-	if res.Hash != nil {
-		txHash = res.Hash.String()
-	}
-
-	parsedLogs, _ := sdk.ParseABCILogs(res.CheckTx.Log)
-
-	return &sdk.TxResponse{
-		Height:    res.Height,
-		TxHash:    txHash,
-		Codespace: res.CheckTx.Codespace,
-		Code:      res.CheckTx.Code,
-		Data:      strings.ToUpper(hex.EncodeToString(res.CheckTx.Data)),
-		RawLog:    res.CheckTx.Log,
-		Logs:      parsedLogs,
-		Info:      res.CheckTx.Info,
-		GasWanted: res.CheckTx.GasWanted,
-		GasUsed:   res.CheckTx.GasUsed,
-		Events:    res.CheckTx.Events,
-	}
-}
-
-func newTxResponseDeliverTx(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
-	if res == nil {
-		return nil
-	}
-
-	var txHash string
-	if res.Hash != nil {
-		txHash = res.Hash.String()
-	}
-
-	parsedLogs, _ := sdk.ParseABCILogs(res.TxResult.Log)
-
-	return &sdk.TxResponse{
-		Height:    res.Height,
-		TxHash:    txHash,
-		Codespace: res.TxResult.Codespace,
-		Code:      res.TxResult.Code,
-		Data:      strings.ToUpper(hex.EncodeToString(res.TxResult.Data)),
-		RawLog:    res.TxResult.Log,
-		Logs:      parsedLogs,
-		Info:      res.TxResult.Info,
-		GasWanted: res.TxResult.GasWanted,
-		GasUsed:   res.TxResult.GasUsed,
-		Events:    res.TxResult.Events,
-	}
-}
-
-func newResponseFormatBroadcastTxCommit(res *coretypes.ResultBroadcastTxCommit) *sdk.TxResponse {
-	if res == nil {
-		return nil
-	}
-
-	if !res.CheckTx.IsOK() {
-		return newTxResponseCheckTx(res)
-	}
-
-	return newTxResponseDeliverTx(res)
-}
-
 // QueryEventForTxCmd is an alias for WaitTxCmd, kept for backwards compatibility.
 func QueryEventForTxCmd() *cobra.Command {
 	return WaitTxCmd()
 }
 
-// WaitTx returns a CLI command that waits for a transaction with the given hash to be included in a block.
+// WaitTxCmd returns a CLI command that waits for a transaction with the given hash to be included in a block.
 func WaitTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "wait-tx [hash]",
@@ -120,58 +52,38 @@ $ %[1]s tx [flags] | %[1]s q wait-tx
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 
-			var hash []byte
-			if len(args) == 0 {
+			txSubmitted := func() (*sdk.TxResponse, []byte, error) {
+				if len(args) > 0 {
+					// read hash from args
+					hashByt, err := hex.DecodeString(args[0])
+					if err != nil {
+						return nil, nil, err
+					}
+
+					return nil, hashByt, nil
+				}
+
 				// read hash from stdin
 				in, err := io.ReadAll(cmd.InOrStdin())
 				if err != nil {
-					return err
+					return nil, nil, err
 				}
 				hashByt, err := parseHashFromInput(in)
 				if err != nil {
-					return err
+					return nil, nil, err
 				}
 
-				hash = hashByt
-			} else {
-				// read hash from args
-				hashByt, err := hex.DecodeString(args[0])
-				if err != nil {
-					return err
-				}
-
-				hash = hashByt
+				return nil, hashByt, nil
 			}
 
-			res, err := clientCtx.Client.Tx(ctx, hash, false)
-			if err == nil {
-				// tx already included in a block
-				res := &coretypes.ResultBroadcastTxCommit{
-					TxResult: res.TxResult,
-					Hash:     res.Hash,
-					Height:   res.Height,
-				}
-				return clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(res))
+			res, err := clientCtx.WaitTx(ctx, txSubmitted)
+			if err != nil {
+				return err
 			}
-
-			waitTxCh := client.WaitTx(ctx, clientCtx.NodeURI, string(hash))
-			waitTxResult := <-waitTxCh
-			if waitTxResult.Err != nil {
-				return waitTxResult.Err
-			}
-
-			txe := waitTxResult.BlockInclusion
-
-			broadcastRes := &coretypes.ResultBroadcastTxCommit{
-				TxResult: txe.Result,
-				Hash:     tmtypes.Tx(txe.Tx).Hash(),
-				Height:   txe.Height,
-			}
-
-			// Propagate the printing error, if any.
-			return clientCtx.PrintProto(newResponseFormatBroadcastTxCommit(broadcastRes))
+			return clientCtx.PrintProto(res)
 		},
 	}
+
 	cmd.Flags().Duration(TimeoutFlag, 15*time.Second, "The maximum time to wait for the transaction to be included in a block")
 	flags.AddQueryFlagsToCmd(cmd)
 

--- a/scripts/go-lint-all.bash
+++ b/scripts/go-lint-all.bash
@@ -8,9 +8,9 @@ export REPO_ROOT
 lint_module() {
   local root="$1"
   shift
-  cd "$(dirname "$root")" &&
+  (cd "$(dirname "$root")" &&
     echo "linting $(grep "^module" go.mod) [$(date -Iseconds -u)]" &&
-    golangci-lint run ./... -c "${REPO_ROOT}/.golangci.yml" "$@"
+    golangci-lint run ./... -c "${REPO_ROOT}/.golangci.yml" "$@")
 }
 export -f lint_module
 
@@ -28,10 +28,16 @@ else
     exit 0
   fi
 
+  status=0
   for f in $(dirname $(echo "$GIT_DIFF" | tr -d "'") | uniq); do
     echo "linting $f [$(date -Iseconds -u)]" &&
-    cd $f &&
-    golangci-lint run ./... -c "${REPO_ROOT}/.golangci.yml" "$@" &&
-    cd $REPO_ROOT
+    (cd "$f" &&
+    golangci-lint run ./... -c "${REPO_ROOT}/.golangci.yml" "$@") || status=$?
   done
+  if [[ $status -eq 0 ]]; then
+    echo "linting succeeded"
+  else
+    echo "linting failed"
+  fi
+  exit $status
 fi

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -176,7 +176,6 @@ func TestAppImportExport(t *testing.T) {
 	ctxA := app.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
 	ctxB := newApp.NewContextLegacy(true, cmtproto.Header{Height: app.LastBlockHeight()})
 	_, err = newApp.ModuleManager.InitGenesis(ctxB, app.AppCodec(), genesisState)
-
 	if err != nil {
 		if strings.Contains(err.Error(), "validator set is empty after InitGenesis") {
 			logger.Info("Skipping simulation as all validators have been unbonded")

--- a/store/rootmulti/store.go
+++ b/store/rootmulti/store.go
@@ -898,7 +898,6 @@ func (rs *Store) Snapshot(height uint64, protoWriter protoio.Writer) error {
 
 			return nil
 		}()
-
 		if err != nil {
 			return err
 		}

--- a/store/snapshots/manager_test.go
+++ b/store/snapshots/manager_test.go
@@ -325,7 +325,6 @@ func TestManager_CannotRestoreTooLargeItem(t *testing.T) {
 	// Feeding the chunks fails
 	for _, chunk := range chunks {
 		_, err = manager.RestoreChunk(chunk)
-
 		if err != nil {
 			break
 		}

--- a/tests/integration/staking/keeper/delegation_test.go
+++ b/tests/integration/staking/keeper/delegation_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/assert"
 
 	"cosmossdk.io/math"
@@ -13,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	"github.com/cosmos/cosmos-sdk/x/staking/testutil"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUnbondingDelegationsMaxEntries(t *testing.T) {
@@ -232,8 +232,8 @@ func TestTransferUnbonding(t *testing.T) {
 
 	addrDels, valAddrs := generateAddresses(f, 100)
 
-	//addrDels := simapp.AddTestAddrsIncremental(app, ctx, 2, math.NewInt(10000))
-	//valAddrs := simtestutil.ConvertAddrsToValAddrs(addrDels)
+	// addrDels := simapp.AddTestAddrsIncremental(app, ctx, 2, math.NewInt(10000))
+	// valAddrs := simtestutil.ConvertAddrsToValAddrs(addrDels)
 
 	// try to transfer when there's nothing
 	transferred, err := f.stakingKeeper.TransferUnbonding(f.sdkCtx, addrDels[0], addrDels[1], valAddrs[0], math.NewInt(30))

--- a/tests/integration/vesting/keeper/vesting_account_test.go
+++ b/tests/integration/vesting/keeper/vesting_account_test.go
@@ -5,12 +5,16 @@ import (
 	"testing"
 	stdtime "time"
 
+	cmtprototypes "github.com/cometbft/cometbft/proto/tendermint/types"
+	"github.com/cometbft/cometbft/types/time"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/log"
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
-	cmtprototypes "github.com/cometbft/cometbft/proto/tendermint/types"
-	"github.com/cometbft/cometbft/types/time"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -33,8 +37,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/stretchr/testify/require"
-	"gotest.tools/v3/assert"
 )
 
 var (
@@ -121,13 +123,13 @@ func initFixtures(t *testing.T) *fixture {
 	authModule := auth.NewAppModule(cdc, accountKeeper, authsims.RandomGenesisAccounts, nil)
 	bankModule := bank.NewAppModule(cdc, bankKeeper, accountKeeper, nil)
 	stakingModule := staking.NewAppModule(cdc, stakingKeeper, accountKeeper, bankKeeper, nil)
-	//mintModule := mint.NewAppModule(cdc, mintKeeper, accountKeeper, nil, nil)
+	// mintModule := mint.NewAppModule(cdc, mintKeeper, accountKeeper, nil, nil)
 
 	integrationApp := integration.NewIntegrationApp(newCtx, logger, keys, cdc, map[string]appmodule.AppModule{
 		authtypes.ModuleName:    authModule,
 		banktypes.ModuleName:    bankModule,
 		stakingtypes.ModuleName: stakingModule,
-		//minttypes.ModuleName:    mintModule,
+		// minttypes.ModuleName:    mintModule,
 	})
 
 	sdkCtx := sdk.UnwrapSDKContext(integrationApp.Context())
@@ -166,7 +168,6 @@ func TestCreatePeriodicVestingAccBricked(t *testing.T) {
 	bacc, origCoins := initBaseAccount()
 	_, err := vestingtypes.NewPeriodicVestingAccount(bacc, origCoins, now.Unix(), badPeriods)
 	assert.Error(t, err, "period #1 has invalid coins: -9000fee")
-
 }
 
 func TestAddGrantPeroidicVestingAcc(t *testing.T) {
@@ -225,7 +226,7 @@ func TestAddGrantPeroidicVestingAcc(t *testing.T) {
 	require.Equal(t, int64(0), pva.DelegatedVesting.AmountOf(stakeDenom).Int64())
 	require.Equal(t, int64(0), pva.DelegatedFree.AmountOf(stakeDenom).Int64())
 
-	//f.accountKeeper.SetAccount(ctx, pva)
+	// f.accountKeeper.SetAccount(ctx, pva)
 	// fund the vesting account with new grant (old has vested and transferred out)
 	err = banktestutil.FundAccount(ctx, f.bankKeeper, pva.GetAddress(), origCoins)
 	require.NoError(t, err)
@@ -236,9 +237,9 @@ func TestAddGrantPeroidicVestingAcc(t *testing.T) {
 	tadr := pva.GetAddress()
 	co := c(stake(1))
 	err = f.bankKeeper.SendCoins(ctx, tadr, dest, co)
-	//require.Error(t, err)
+	// require.Error(t, err)
 	ctx = ctx.WithBlockTime(now.Add(1500 * stdtime.Second))
-	//err = f.bankKeeper.SendCoins(ctx, pva.GetAddress(), dest, origCoins)
+	// err = f.bankKeeper.SendCoins(ctx, pva.GetAddress(), dest, origCoins)
 	require.NoError(t, err)
 }
 
@@ -303,7 +304,7 @@ func TestAddGrantPeriodicVestingAcc_negAmount(t *testing.T) {
 
 	addr := pva.GetAddress()
 
-	// At now+150 add a new grant wich attempts to prematurly vest the grant
+	// At now+150 add a new grant which attempts to prematurely vest the grant
 	bogusPeriods := vestingtypes.Periods{
 		{Length: 1, Amount: c(fee(750))},
 		{Length: 1000, Amount: []sdk.Coin{{Denom: feeDenom, Amount: math.NewInt(-749)}}},
@@ -316,7 +317,7 @@ func TestAddGrantPeriodicVestingAcc_negAmount(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, int64(100), f.bankKeeper.GetBalance(ctx, addr, stakeDenom).Amount.Int64())
 
-	// try to transfer the orginal grant before its time
+	// try to transfer the original grant before its time
 	ctx = ctx.WithBlockTime(now.Add(160 * stdtime.Second))
 	_, _, dest := testdata.KeyTestPubAddr()
 	err = f.bankKeeper.SendCoins(ctx, addr, dest, c(fee(750)))

--- a/x/auth/vesting/client/cli/tx.go
+++ b/x/auth/vesting/client/cli/tx.go
@@ -357,23 +357,16 @@ Currently only supported for ClawbackVestingAccount.`,
 // Returrns start time, periods, and error.
 
 func readScheduleFile(path string) (int64, []types.Period, error) {
-
 	contents, err := os.ReadFile(path)
-
 	if err != nil {
-
 		return 0, nil, err
-
 	}
 
 	var data VestingData
 
 	err = json.Unmarshal(contents, &data)
-
 	if err != nil {
-
 		return 0, nil, err
-
 	}
 
 	startTime := data.StartTime
@@ -383,17 +376,12 @@ func readScheduleFile(path string) (int64, []types.Period, error) {
 	for i, p := range data.Periods {
 
 		amount, err := sdk.ParseCoinsNormalized(p.Coins)
-
 		if err != nil {
-
 			return 0, nil, err
-
 		}
 
 		if p.Length < 1 {
-
 			return 0, nil, fmt.Errorf("invalid period length of %d in period %d, length must be greater than 0", p.Length, i)
-
 		}
 
 		period := types.Period{Length: p.Length, Amount: amount}
@@ -403,5 +391,4 @@ func readScheduleFile(path string) (int64, []types.Period, error) {
 	}
 
 	return startTime, periods, nil
-
 }

--- a/x/auth/vesting/cmd/vestcalc/vestcalc.go
+++ b/x/auth/vesting/cmd/vestcalc/vestcalc.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	sdkmath "cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/client/cli"
 )
@@ -370,7 +371,7 @@ func (id *isoDate) String() string {
 }
 
 // isoDateFlag makes a new isoDate flag, accessed as a time.Time.
-func isoDateFlag(name string, usage string) *time.Time {
+func isoDateFlag(name, usage string) *time.Time {
 	id := isoDate{time.Time{}}
 	flag.CommandLine.Var(&id, name, usage)
 	return &id.Time
@@ -407,7 +408,7 @@ func (dates *isoDateList) String() string {
 }
 
 // isoDateListFlag makes a new isoDateList flag.
-func isoDateListFlag(name string, usage string) *isoDateList {
+func isoDateListFlag(name, usage string) *isoDateList {
 	dates := isoDateList([]time.Time{})
 	flag.Var(&dates, name, usage)
 	return &dates
@@ -434,7 +435,7 @@ func (it *isoTime) String() string {
 }
 
 // isoTimeFlag makes a new isoTime flag, accessed as a time.Time.
-func isoTimeFlag(name string, value string, usage string) *time.Time {
+func isoTimeFlag(name, value, usage string) *time.Time {
 	t, err := time.Parse(hhmmFmt, value)
 	if err != nil {
 		t = time.Time{}

--- a/x/auth/vesting/cmd/vestcalc/vestcalc_test.go
+++ b/x/auth/vesting/cmd/vestcalc/vestcalc_test.go
@@ -40,7 +40,7 @@ func coins(s string) sdk.Coins {
 	return c
 }
 
-func evt(ts string, cs string) event {
+func evt(ts, cs string) event {
 	tm := iso(ts)
 	c := coins(cs)
 	return event{Time: tm, Coins: c}
@@ -282,7 +282,7 @@ func TestApplyCliff(t *testing.T) {
 }
 
 func TestWrite(t *testing.T) {
-	// Use an explicit timezone for consistant intervals between timestamps.
+	// Use an explicit timezone for consistent intervals between timestamps.
 	oldLoc := time.Local
 	loc, err := time.LoadLocation("America/Los_Angeles")
 	if err != nil {

--- a/x/auth/vesting/msg_server.go
+++ b/x/auth/vesting/msg_server.go
@@ -287,12 +287,10 @@ func (s msgServer) Clawback(goCtx context.Context, msg *types.MsgClawback) (*typ
 	acc := ak.GetAccount(ctx, addr)
 	if acc == nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "account %s does not exist", msg.Address)
-
 	}
 	va, ok := acc.(*types.ClawbackVestingAccount)
 	if !ok {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "account not subject to clawback: %s", msg.Address)
-
 	}
 
 	err = va.Clawback(ctx, funder, dest, ak, bk, s.StakingKeeper)
@@ -318,12 +316,10 @@ func (s msgServer) ReturnGrants(goCtx context.Context, msg *types.MsgReturnGrant
 	acc := ak.GetAccount(ctx, addr)
 	if acc == nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "account %s does not exist", msg.Address)
-
 	}
 	va, ok := acc.(*types.ClawbackVestingAccount)
 	if !ok {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "account does not support return-grants: %s", msg.Address)
-
 	}
 
 	va.ReturnGrants(ctx, ak, s.BankKeeper, s.StakingKeeper)

--- a/x/auth/vesting/msg_server_test.go
+++ b/x/auth/vesting/msg_server_test.go
@@ -447,7 +447,6 @@ func (s *VestingTestSuite) TestCreatePeriodicVestingAccount() {
 				s.bankKeeper.EXPECT().BlockedAddr(to2Addr).Return(false)
 				s.bankKeeper.EXPECT().SendCoins(gomock.Any(), fromAddr, to2Addr, gomock.Any()).Return(nil)
 				s.bankKeeper.EXPECT().IsSendEnabledCoins(gomock.Any(), gomock.Any()).Return(nil)
-
 			},
 			input: vestingtypes.NewMsgCreatePeriodicVestingAccount(
 				fromAddr,

--- a/x/auth/vesting/types/expected_keepers.go
+++ b/x/auth/vesting/types/expected_keepers.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	context "context"
+
 	"cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )

--- a/x/auth/vesting/types/genesis_test.go
+++ b/x/auth/vesting/types/genesis_test.go
@@ -25,7 +25,6 @@ func TestValidateGenesisInvalidAccounts(t *testing.T) {
 	baseVestingAcc, err := NewBaseVestingAccount(acc1, acc1Balance, endTime)
 	require.NoError(t, err)
 
-
 	// invalid delegated vesting
 	baseVestingAcc.DelegatedVesting = acc1Balance.Add(acc1Balance...)
 

--- a/x/auth/vesting/types/msgs.go
+++ b/x/auth/vesting/types/msgs.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/auth/vesting/types/msgs_test.go
+++ b/x/auth/vesting/types/msgs_test.go
@@ -3,10 +3,11 @@ package types
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestVestingAccountMsg(t *testing.T) {
@@ -17,6 +18,7 @@ func TestVestingAccountMsg(t *testing.T) {
 	msg := NewMsgCreateVestingAccount(fromAddr, toAddr, amount, endTime, false)
 	require.NotNil(t, msg)
 }
+
 func TestClawbackVestingAccountMsg(t *testing.T) {
 	_, _, fromAddr := KeyTestPubAddr()
 	_, _, toAddr := KeyTestPubAddr()

--- a/x/auth/vesting/types/period_test.go
+++ b/x/auth/vesting/types/period_test.go
@@ -6,7 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func mkper(length int64, amount int64) Period {
+func mkper(length, amount int64) Period {
 	return Period{
 		Length: length,
 		Amount: sdk.NewCoins(sdk.NewInt64Coin("test", amount)),

--- a/x/auth/vesting/types/vesting_account.go
+++ b/x/auth/vesting/types/vesting_account.go
@@ -7,14 +7,14 @@ import (
 	stdmath "math"
 	"time"
 
-	sdkerrors "cosmossdk.io/errors"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	errors2 "github.com/cosmos/cosmos-sdk/types/errors"
 	"sigs.k8s.io/yaml"
 
+	sdkerrors "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	errors2 "github.com/cosmos/cosmos-sdk/types/errors"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	vestexported "github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
 )
@@ -970,7 +970,6 @@ func (va *ClawbackVestingAccount) Clawback(ctx sdk.Context, requestor, dest sdk.
 				panic(err) // shouldn't happen
 			}
 			validator, err := sk.GetValidator(ctx, validatorAddr)
-
 			if err != nil {
 				// validator has been removed
 				continue

--- a/x/auth/vesting/types/vesting_account_internal_test.go
+++ b/x/auth/vesting/types/vesting_account_internal_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
+	tmtime "github.com/cometbft/cometbft/types/time"
+	"github.com/stretchr/testify/require"
+
 	"github.com/cosmos/cosmos-sdk/testutil/testdata"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/stretchr/testify/require"
-
-	tmtime "github.com/cometbft/cometbft/types/time"
 )
 
 var (

--- a/x/distribution/keeper/grpc_query.go
+++ b/x/distribution/keeper/grpc_query.go
@@ -331,7 +331,6 @@ func (k Querier) DelegatorValidators(ctx context.Context, req *types.QueryDelega
 			return false
 		},
 	)
-
 	if err != nil {
 		return nil, err
 	}

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -242,7 +242,6 @@ $ %s tx gov submit-legacy-proposal --title="Test Proposal" --description="My awe
 
 			if len(args) == 0 {
 				return fmt.Errorf("failed to parse proposal: %w", err)
-
 			}
 
 			// otherwise try to interpret as a new post (0.46) submit-proposal

--- a/x/gov/keeper/tally.go
+++ b/x/gov/keeper/tally.go
@@ -91,7 +91,6 @@ func (keeper Keeper) Tally(ctx context.Context, proposal v1.Proposal) (passes, b
 
 		return false, keeper.Votes.Remove(ctx, collections.Join(vote.ProposalId, sdk.AccAddress(voter)))
 	})
-
 	if err != nil {
 		return false, false, tallyResults, err
 	}


### PR DESCRIPTION
## Description

Fixes failures found in Agoric/agoric-sdk#11378, where `agd query wait-tx` would deadlock if run between the Tx event raised by the RPC node, and when it actually appeared on chain to be queriable by `agd query tx`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
